### PR TITLE
Do not hardcode exact rocm path in `compile_flags.txt`

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,2 +1,2 @@
---rocm-path=/opt/rocm-6.2.0/
+--rocm-path=/opt/rocm/
 --std=c++20


### PR DESCRIPTION
Use the default version provided through the symlink instead.