### PR TITLE
Add initial matvec kernel code

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-set -eux
+set -euxo pipefail
 
 if [[ ! -d build ]]
 then
   mkdir build
 fi
 
-executable=build/hip-matmul
+declare -a KERNELS_TO_RUN=("matmul" "matvec")
 
-hipcc matmul.hip -std=c++20 -Wall -Wextra -O3 -o "${executable}" -save-temps=obj
+if [ ! -z ${KERNEL+x} ]; then
+  KERNELS_TO_RUN=("${KERNEL}")
+fi
 
-"${executable}"
+for kernel in "${KERNELS_TO_RUN[@]}" ; do
+  echo "Build and test: ${kernel}"
+  executable="build/hip-${kernel}"
+  hipcc "${kernel}.hip" -std=c++20 -Wall -Wextra -O3 -o "${executable}" -save-temps=obj
+  "${executable}"
+done

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -7,13 +7,9 @@ then
   mkdir build
 fi
 
-declare -a KERNELS_TO_RUN=("matmul" "matvec")
+readonly KERNELS_TO_RUN="${KERNELS_TO_RUN:-matmul matvec}"
 
-if [ ! -z ${KERNEL+x} ]; then
-  KERNELS_TO_RUN=("${KERNEL}")
-fi
-
-for kernel in "${KERNELS_TO_RUN[@]}" ; do
+for kernel in $KERNELS_TO_RUN; do
   echo "Build and test: ${kernel}"
   executable="build/hip-${kernel}"
   hipcc "${kernel}.hip" -std=c++20 -Wall -Wextra -O3 -o "${executable}" -save-temps=obj

--- a/common.hip
+++ b/common.hip
@@ -1,0 +1,127 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef HIP_MATMUL_COMMON
+#define HIP_MATMUL_COMMON
+
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <random>
+#include <vector>
+
+inline void hip_check_impl(hipError_t hip_error_code, const char *condstr,
+                    const char *file, int line) {
+  if (hip_error_code != hipSuccess) {
+    fprintf(stderr, "HIP Error \"%s\" produced by `%s` at %s:%d\n",
+            hipGetErrorString(hip_error_code), condstr, file, line);
+    exit(EXIT_FAILURE);
+  }
+}
+
+#define HIP_CHECK(expr) hip_check_impl(expr, #expr, __FILE__, __LINE__)
+
+inline int getIntEnvVar(const char *name, int default_val) {
+  const char *env = std::getenv(name);
+  return env ? std::stoi(env) : default_val;
+};
+
+struct MNKShape {
+  int M, N, K;
+};
+
+enum class Type { SI8, SI16, SI32, FP16, FP32 };
+
+inline const char *str(Type t) {
+  switch (t) {
+  case Type::SI8:
+    return "si8";
+  case Type::SI16:
+    return "si16";
+  case Type::SI32:
+    return "si32";
+  case Type::FP16:
+    return "fp16";
+  case Type::FP32:
+    return "fp32";
+  }
+}
+
+inline __device__ __host__ int type_size(Type t) {
+  switch (t) {
+  case Type::SI8:
+    return 1;
+  case Type::SI16:
+    return 2;
+  case Type::SI32:
+    return 4;
+  case Type::FP16:
+    return 2;
+  case Type::FP32:
+    return 4;
+  }
+}
+
+template <Type t> struct CTypeImpl {};
+template <> struct CTypeImpl<Type::SI8> {
+  using type = int8_t;
+};
+template <> struct CTypeImpl<Type::SI16> {
+  using type = int16_t;
+};
+template <> struct CTypeImpl<Type::SI32> {
+  using type = int32_t;
+};
+template <> struct CTypeImpl<Type::FP16> {
+  using type = _Float16;
+};
+template <> struct CTypeImpl<Type::FP32> {
+  using type = float;
+};
+template <Type t> using CType = typename CTypeImpl<t>::type;
+
+template <typename A, typename B>
+__device__ __host__ std::common_type_t<A, B> ceil_div(A a, B b) {
+  return (a + b - 1) / b;
+}
+
+template <int Po2, typename A> __device__ __host__ A round_up_to_po2(A a) {
+  static_assert(Po2 > 0 && (Po2 & (Po2 - 1)) == 0);
+  return ((a - 1) | (Po2 - 1)) + 1;
+}
+
+template <Type type>
+void fillRandomBuffer(int size, std::minstd_rand &r, void *out_buffer) {
+  using T = CType<type>;
+  T *out_buffer_typed = static_cast<T *>(out_buffer);
+  for (int i = 0; i < size; ++i) {
+    // Generate small integers in [-2, +2] so products are in [-4, +4] so
+    // accumulators are in [-4K, +4K] for accumulation depth K so they're
+    // exactly representable, float rounding is exact and we don't need
+    // fuzzy compares.
+    out_buffer_typed[i] = static_cast<T>(static_cast<int>((r() % 5)) - 2);
+  }
+}
+
+inline std::vector<std::byte> makeRandomBuffer(Type type, int size,
+                                        std::minstd_rand &r) {
+  int bytes = size * type_size(type);
+  std::vector<std::byte> result(bytes);
+  if (type == Type::SI8) {
+    fillRandomBuffer<Type::SI8>(size, r, result.data());
+  } else if (type == Type::SI16) {
+    fillRandomBuffer<Type::SI16>(size, r, result.data());
+  } else if (type == Type::SI32) {
+    fillRandomBuffer<Type::SI32>(size, r, result.data());
+  } else if (type == Type::FP16) {
+    fillRandomBuffer<Type::FP16>(size, r, result.data());
+  } else if (type == Type::FP32) {
+    fillRandomBuffer<Type::FP32>(size, r, result.data());
+  }
+  return result;
+}
+
+#endif

--- a/matmul.hip
+++ b/matmul.hip
@@ -13,7 +13,6 @@
 #include <typeinfo>
 #include <vector>
 
-
 typedef void (*mmt_func_t)(const void *, const void *, void *, void *, int, int,
                            int);
 
@@ -30,23 +29,23 @@ struct TiledMmtShape {
   tile_layout_func_t A_tile_layout, B_tile_layout, C_tile_layout;
 };
 
-inline __device__ __host__ TiledMatrixShape A_shape(const TiledMmtShape &s) {
+__device__ __host__ TiledMatrixShape A_shape(const TiledMmtShape &s) {
   return {s.outer.M, s.outer.K, s.tile.M, s.tile.K, s.A_tile_layout};
 }
 
-inline __device__ __host__ TiledMatrixShape B_shape(const TiledMmtShape &s) {
+__device__ __host__ TiledMatrixShape B_shape(const TiledMmtShape &s) {
   return {s.outer.N, s.outer.K, s.tile.N, s.tile.K, s.B_tile_layout};
 }
 
-inline __device__ __host__ TiledMatrixShape C_shape(const TiledMmtShape &s) {
+__device__ __host__ TiledMatrixShape C_shape(const TiledMmtShape &s) {
   return {s.outer.M, s.outer.N, s.tile.M, s.tile.N, s.C_tile_layout};
 }
 
-inline __device__ __host__ int flatsize(const TiledMatrixShape &s) {
+__device__ __host__ int flatsize(const TiledMatrixShape &s) {
   return s.rows_outer * s.cols_outer * s.rows_tile * s.cols_tile;
 }
 
-inline __device__ __host__ int offset(const TiledMatrixShape &s, int r_outer,
+__device__ __host__ int offset(const TiledMatrixShape &s, int r_outer,
                                int c_outer, int r_tile, int c_tile) {
   return s.tile_layout(r_tile, c_tile) +
          s.rows_tile * s.cols_tile * (c_outer + s.cols_outer * r_outer);
@@ -60,9 +59,9 @@ inline __device__ __host__ int offset(const TiledMatrixShape &s, int r_outer,
 //
 // The data layout is tiled with tile sizes given by the {M,N,K}_tile methods
 // and tile layouts given by the {A,B,C}_layout methods.
-class MatvecKernel {
+class MmtKernel {
 public:
-  virtual ~MatvecKernel() {};
+  virtual ~MmtKernel() {};
   // Returns the element type of the A-matrix (LHS)
   virtual Type A_type() const = 0;
   // Returns the element type of the B-matrix (RHS)
@@ -95,7 +94,7 @@ public:
   virtual int aux_buffer_size(const MNKShape & /*outer*/) const { return 0; }
 };
 
-MNKShape getCheckProblemSize(const MatvecKernel &kernel) {
+MNKShape getCheckProblemSize(const MmtKernel &kernel) {
   int M = getIntEnvVar("M", 4096);
   int N = getIntEnvVar("N", 4096);
   int K = getIntEnvVar("K", 4096);
@@ -106,7 +105,7 @@ MNKShape getCheckProblemSize(const MatvecKernel &kernel) {
   return o;
 }
 
-TiledMmtShape getTestShape(const MatvecKernel &kernel, const MNKShape &o) {
+TiledMmtShape getTestShape(const MmtKernel &kernel, const MNKShape &o) {
   TiledMmtShape s;
   s.outer = o;
   s.tile.M = kernel.M_tile();
@@ -118,7 +117,7 @@ TiledMmtShape getTestShape(const MatvecKernel &kernel, const MNKShape &o) {
   return s;
 }
 
-dim3 getLaunchGrid(const MatvecKernel &kernel, const TiledMmtShape &s) {
+dim3 getLaunchGrid(const MmtKernel &kernel, const TiledMmtShape &s) {
   return kernel.get_work_centric_grid(s.outer).value_or(
       dim3(s.outer.M, s.outer.N));
 }
@@ -185,7 +184,7 @@ void checkMmtResults(Type A_type, Type B_type, Type C_type,
   abort();
 }
 
-void check(const MatvecKernel &kernel, const MNKShape &o) {
+void check(const MmtKernel &kernel, const MNKShape &o) {
   TiledMmtShape s = getTestShape(kernel, o);
   std::minstd_rand random_engine;
   std::vector<std::byte> A_host_data =
@@ -240,7 +239,7 @@ void check(const MatvecKernel &kernel, const MNKShape &o) {
   HIP_CHECK(hipFree(shape_device_buffer));
 }
 
-void check(const MatvecKernel &kernel) {
+void check(const MmtKernel &kernel) {
   std::printf("  Checking correctness... ");
   // Test with more generic shapes than just M==N==K==2^x.
   for (MNKShape o : {MNKShape{1, 1, 1}, MNKShape{2, 1, 1}, MNKShape{1, 2, 1},
@@ -253,7 +252,7 @@ void check(const MatvecKernel &kernel) {
   std::printf("OK\n");
 }
 
-void benchmark(const MatvecKernel &kernel, const MNKShape &o) {
+void benchmark(const MmtKernel &kernel, const MNKShape &o) {
   TiledMmtShape s = getTestShape(kernel, o);
   std::printf("  Benchmarking: total MxNxK=%dx%dx%d, outer MxNxK=%dx%dx%d ... ",
               s.outer.M * s.tile.M, s.outer.N * s.tile.N, s.outer.K * s.tile.K,
@@ -347,7 +346,7 @@ void benchmark(const MatvecKernel &kernel, const MNKShape &o) {
   HIP_CHECK(hipFree(shape_device_buffer));
 }
 
-void test(const MatvecKernel &kernel) {
+void test(const MmtKernel &kernel) {
   char *name =
       abi::__cxa_demangle(typeid(kernel).name(), nullptr, nullptr, nullptr);
   const char *filter = getenv("FILTER");
@@ -370,7 +369,7 @@ void test(const MatvecKernel &kernel) {
 
 template <Type T_A_type, Type T_B_type, Type T_C_type, int T_M_tile,
           int T_N_tile, int T_K_tile>
-class MmtKernel_generic : public MatvecKernel {
+class MmtKernel_generic : public MmtKernel {
   virtual Type A_type() const override { return T_A_type; }
   virtual Type B_type() const override { return T_B_type; }
   virtual Type C_type() const override { return T_C_type; }
@@ -419,7 +418,7 @@ class MmtKernel_generic : public MatvecKernel {
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MatvecKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -473,7 +472,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MatvecKernel {
 };
 
 class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC
-    : public MatvecKernel {
+    : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -522,7 +521,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -566,7 +565,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MatvecKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -618,7 +617,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MatvecKernel 
 };
 
 class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4
-    : public MatvecKernel {
+    : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -696,7 +695,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4
   }
 };
 
-class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
+class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -748,7 +747,7 @@ class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel
   }
 };
 
-class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
+class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -807,7 +806,7 @@ class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel
   }
 };
 
-class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MatvecKernel {
+class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MmtKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -942,7 +941,7 @@ class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MatvecKernel
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1082,7 +1081,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1237,7 +1236,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1329,7 +1328,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1423,7 +1422,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1543,7 +1542,7 @@ class
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1656,7 +1655,7 @@ class
 
 template <int MS, int NS>
 class MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1754,7 +1753,7 @@ class MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
@@ -1854,7 +1853,7 @@ class
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP16; }
@@ -1946,7 +1945,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP16; }
@@ -2045,8 +2044,6 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
   }
 };
 
-
-
 // A simple Stream-K kernel variant of
 // MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2.
 //
@@ -2068,7 +2065,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
 //
 template <int MS, int NS>
 class MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   // Defining some values as constants as they will be needed in static methods
@@ -2407,7 +2404,7 @@ class MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2499,7 +2496,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2590,7 +2587,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2685,7 +2682,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2817,7 +2814,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3
-    : public MatvecKernel {
+    : public MmtKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }

--- a/matmul.hip
+++ b/matmul.hip
@@ -94,7 +94,7 @@ public:
   virtual int aux_buffer_size(const MNKShape & /*outer*/) const { return 0; }
 };
 
-MNKShape getCheckProblemSize(const MmtKernel &kernel) {
+MNKShape getBenchmarkMNKShape(const MmtKernel &kernel) {
   int M = getIntEnvVar("M", 4096);
   int N = getIntEnvVar("N", 4096);
   int K = getIntEnvVar("K", 4096);
@@ -363,7 +363,7 @@ void test(const MmtKernel &kernel) {
     check(kernel);
   }
 
-  MNKShape o = getCheckProblemSize(kernel);
+  MNKShape o = getBenchmarkMNKShape(kernel);
   benchmark(kernel, o);
 }
 

--- a/matmul.hip
+++ b/matmul.hip
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <hip/hip_runtime.h>
+#include "common.hip"
 
 #include <cstdio>
 #include <cxxabi.h>
@@ -13,21 +13,9 @@
 #include <typeinfo>
 #include <vector>
 
-void hip_check_impl(hipError_t hip_error_code, const char *condstr,
-                    const char *file, int line) {
-  if (hip_error_code != hipSuccess) {
-    fprintf(stderr, "HIP Error \"%s\" produced by `%s` at %s:%d\n",
-            hipGetErrorString(hip_error_code), condstr, file, line);
-    exit(EXIT_FAILURE);
-  }
-}
 
-#define HIP_CHECK(expr) hip_check_impl(expr, #expr, __FILE__, __LINE__)
-
-int getIntEnvVar(const char *name, int default_val) {
-  const char *env = std::getenv(name);
-  return env ? std::stoi(env) : default_val;
-};
+typedef void (*mmt_func_t)(const void *, const void *, void *, void *, int, int,
+                           int);
 
 typedef int (*tile_layout_func_t)(int, int);
 
@@ -37,116 +25,102 @@ struct TiledMatrixShape {
   tile_layout_func_t tile_layout;
 };
 
-struct MNKShape {
-  int M, N, K;
-};
-
 struct TiledMmtShape {
   MNKShape outer, tile;
   tile_layout_func_t A_tile_layout, B_tile_layout, C_tile_layout;
 };
 
-__device__ __host__ TiledMatrixShape A_shape(const TiledMmtShape &s) {
+inline __device__ __host__ TiledMatrixShape A_shape(const TiledMmtShape &s) {
   return {s.outer.M, s.outer.K, s.tile.M, s.tile.K, s.A_tile_layout};
 }
 
-__device__ __host__ TiledMatrixShape B_shape(const TiledMmtShape &s) {
+inline __device__ __host__ TiledMatrixShape B_shape(const TiledMmtShape &s) {
   return {s.outer.N, s.outer.K, s.tile.N, s.tile.K, s.B_tile_layout};
 }
 
-__device__ __host__ TiledMatrixShape C_shape(const TiledMmtShape &s) {
+inline __device__ __host__ TiledMatrixShape C_shape(const TiledMmtShape &s) {
   return {s.outer.M, s.outer.N, s.tile.M, s.tile.N, s.C_tile_layout};
 }
 
-__device__ __host__ int flatsize(const TiledMatrixShape &s) {
+inline __device__ __host__ int flatsize(const TiledMatrixShape &s) {
   return s.rows_outer * s.cols_outer * s.rows_tile * s.cols_tile;
 }
 
-__device__ __host__ int offset(const TiledMatrixShape &s, int r_outer,
+inline __device__ __host__ int offset(const TiledMatrixShape &s, int r_outer,
                                int c_outer, int r_tile, int c_tile) {
   return s.tile_layout(r_tile, c_tile) +
          s.rows_tile * s.cols_tile * (c_outer + s.cols_outer * r_outer);
 }
 
-enum class Type { SI8, SI16, SI32, FP16, FP32 };
-
-const char *str(Type t) {
-  switch (t) {
-  case Type::SI8:
-    return "si8";
-  case Type::SI16:
-    return "si16";
-  case Type::SI32:
-    return "si32";
-  case Type::FP16:
-    return "fp16";
-  case Type::FP32:
-    return "fp32";
+// Base class for matrix-times-matrix-transposed ("mmt") kernels.
+// As the RHS is transposed, the dimensions are:
+// LHS = "A-matrix" : MxK
+// RHS = "B-matrix" : NxK
+// Accumulator = "C-matrix": MxN
+//
+// The data layout is tiled with tile sizes given by the {M,N,K}_tile methods
+// and tile layouts given by the {A,B,C}_layout methods.
+class MatvecKernel {
+public:
+  virtual ~MatvecKernel() {};
+  // Returns the element type of the A-matrix (LHS)
+  virtual Type A_type() const = 0;
+  // Returns the element type of the B-matrix (RHS)
+  virtual Type B_type() const = 0;
+  // Returns the element type of the C-matrix (accumulator/result)
+  virtual Type C_type() const = 0;
+  // Returns the M-dimension tile size (rows of accumulator)
+  virtual int M_tile() const = 0;
+  // Returns the N-dimension tile size (columns of accumulator)
+  virtual int N_tile() const = 0;
+  // Returns the K-dimension tile size (reduction dimension)
+  virtual int K_tile() const = 0;
+  // Returns the offset-computation function describing the A-matrix layout.
+  virtual tile_layout_func_t A_tile_layout() const = 0;
+  // Returns the offset-computation function describing the B-matrix layout.
+  virtual tile_layout_func_t B_tile_layout() const = 0;
+  // Returns the offset-computation function describing the C-matrix layout.
+  virtual tile_layout_func_t C_tile_layout() const = 0;
+  // Returns the number of threads that the kernel requires running on.
+  virtual int num_threads() const = 0;
+  // Returns a pointer to the device kernel.
+  virtual mmt_func_t mmt_func() const = 0;
+  // Optional: kernels may override this method to override the default grid.
+  virtual std::optional<dim3>
+  get_work_centric_grid(const MNKShape & /*outer*/) const {
+    return {};
   }
+  // Optional: kernels may override this to get an auxiliary device buffer of
+  // the given size in bytes.
+  virtual int aux_buffer_size(const MNKShape & /*outer*/) const { return 0; }
+};
+
+MNKShape getCheckProblemSize(const MatvecKernel &kernel) {
+  int M = getIntEnvVar("M", 4096);
+  int N = getIntEnvVar("N", 4096);
+  int K = getIntEnvVar("K", 4096);
+  MNKShape o;
+  o.M = std::max(1, M / kernel.M_tile());
+  o.N = std::max(1, N / kernel.N_tile());
+  o.K = std::max(1, K / kernel.K_tile());
+  return o;
 }
 
-__device__ __host__ int type_size(Type t) {
-  switch (t) {
-  case Type::SI8:
-    return 1;
-  case Type::SI16:
-    return 2;
-  case Type::SI32:
-    return 4;
-  case Type::FP16:
-    return 2;
-  case Type::FP32:
-    return 4;
-  }
+TiledMmtShape getTestShape(const MatvecKernel &kernel, const MNKShape &o) {
+  TiledMmtShape s;
+  s.outer = o;
+  s.tile.M = kernel.M_tile();
+  s.tile.N = kernel.N_tile();
+  s.tile.K = kernel.K_tile();
+  s.A_tile_layout = kernel.A_tile_layout();
+  s.B_tile_layout = kernel.B_tile_layout();
+  s.C_tile_layout = kernel.C_tile_layout();
+  return s;
 }
 
-template <Type t> struct CTypeImpl {};
-template <> struct CTypeImpl<Type::SI8> {
-  using type = int8_t;
-};
-template <> struct CTypeImpl<Type::SI16> {
-  using type = int16_t;
-};
-template <> struct CTypeImpl<Type::SI32> {
-  using type = int32_t;
-};
-template <> struct CTypeImpl<Type::FP16> {
-  using type = _Float16;
-};
-template <> struct CTypeImpl<Type::FP32> {
-  using type = float;
-};
-template <Type t> using CType = typename CTypeImpl<t>::type;
-
-template <Type type>
-void fillRandomBuffer(int size, std::minstd_rand &r, void *out_buffer) {
-  using T = CType<type>;
-  T *out_buffer_typed = static_cast<T *>(out_buffer);
-  for (int i = 0; i < size; ++i) {
-    // Generate small integers in [-2, +2] so products are in [-4, +4] so
-    // accumulators are in [-4K, +4K] for accumulation depth K so they're
-    // exactly representable, float rounding is exact and we don't need
-    // fuzzy compares.
-    out_buffer_typed[i] = static_cast<T>(static_cast<int>((r() % 5)) - 2);
-  }
-}
-
-std::vector<std::byte> makeRandomBuffer(Type type, int size,
-                                        std::minstd_rand &r) {
-  int bytes = size * type_size(type);
-  std::vector<std::byte> result(bytes);
-  if (type == Type::SI8) {
-    fillRandomBuffer<Type::SI8>(size, r, result.data());
-  } else if (type == Type::SI16) {
-    fillRandomBuffer<Type::SI16>(size, r, result.data());
-  } else if (type == Type::SI32) {
-    fillRandomBuffer<Type::SI32>(size, r, result.data());
-  } else if (type == Type::FP16) {
-    fillRandomBuffer<Type::FP16>(size, r, result.data());
-  } else if (type == Type::FP32) {
-    fillRandomBuffer<Type::FP32>(size, r, result.data());
-  }
-  return result;
+dim3 getLaunchGrid(const MatvecKernel &kernel, const TiledMmtShape &s) {
+  return kernel.get_work_centric_grid(s.outer).value_or(
+      dim3(s.outer.M, s.outer.N));
 }
 
 template <Type A_type, Type B_type, Type C_type>
@@ -211,81 +185,7 @@ void checkMmtResults(Type A_type, Type B_type, Type C_type,
   abort();
 }
 
-typedef void (*mmt_func_t)(const void *, const void *, void *, void *, int, int,
-                           int);
-
-// Base class for matrix-times-matrix-transposed ("mmt") kernels.
-// As the RHS is transposed, the dimensions are:
-// LHS = "A-matrix" : MxK
-// RHS = "B-matrix" : NxK
-// Accumulator = "C-matrix": MxN
-//
-// The data layout is tiled with tile sizes given by the {M,N,K}_tile methods
-// and tile layouts given by the {A,B,C}_layout methods.
-class MmtKernel {
-public:
-  virtual ~MmtKernel() {};
-  // Returns the element type of the A-matrix (LHS)
-  virtual Type A_type() const = 0;
-  // Returns the element type of the B-matrix (RHS)
-  virtual Type B_type() const = 0;
-  // Returns the element type of the C-matrix (accumulator/result)
-  virtual Type C_type() const = 0;
-  // Returns the M-dimension tile size (rows of accumulator)
-  virtual int M_tile() const = 0;
-  // Returns the N-dimension tile size (columns of accumulator)
-  virtual int N_tile() const = 0;
-  // Returns the K-dimension tile size (reduction dimension)
-  virtual int K_tile() const = 0;
-  // Returns the offset-computation function describing the A-matrix layout.
-  virtual tile_layout_func_t A_tile_layout() const = 0;
-  // Returns the offset-computation function describing the B-matrix layout.
-  virtual tile_layout_func_t B_tile_layout() const = 0;
-  // Returns the offset-computation function describing the C-matrix layout.
-  virtual tile_layout_func_t C_tile_layout() const = 0;
-  // Returns the number of threads that the kernel requires running on.
-  virtual int num_threads() const = 0;
-  // Returns a pointer to the device kernel.
-  virtual mmt_func_t mmt_func() const = 0;
-  // Optional: kernels may override this method to override the default grid.
-  virtual std::optional<dim3>
-  get_work_centric_grid(const MNKShape & /*outer*/) const {
-    return {};
-  }
-  // Optional: kernels may override this to get an auxiliary device buffer of
-  // the given size in bytes.
-  virtual int aux_buffer_size(const MNKShape & /*outer*/) const { return 0; }
-};
-
-MNKShape getBenchmarkMNKShape(const MmtKernel &kernel) {
-  int M = getIntEnvVar("M", 4096);
-  int N = getIntEnvVar("N", 4096);
-  int K = getIntEnvVar("K", 4096);
-  MNKShape o;
-  o.M = std::max(1, M / kernel.M_tile());
-  o.N = std::max(1, N / kernel.N_tile());
-  o.K = std::max(1, K / kernel.K_tile());
-  return o;
-}
-
-TiledMmtShape getTestShape(const MmtKernel &kernel, const MNKShape &o) {
-  TiledMmtShape s;
-  s.outer = o;
-  s.tile.M = kernel.M_tile();
-  s.tile.N = kernel.N_tile();
-  s.tile.K = kernel.K_tile();
-  s.A_tile_layout = kernel.A_tile_layout();
-  s.B_tile_layout = kernel.B_tile_layout();
-  s.C_tile_layout = kernel.C_tile_layout();
-  return s;
-}
-
-dim3 getLaunchGrid(const MmtKernel &kernel, const TiledMmtShape &s) {
-  return kernel.get_work_centric_grid(s.outer).value_or(
-      dim3(s.outer.M, s.outer.N));
-}
-
-void check(const MmtKernel &kernel, const MNKShape &o) {
+void check(const MatvecKernel &kernel, const MNKShape &o) {
   TiledMmtShape s = getTestShape(kernel, o);
   std::minstd_rand random_engine;
   std::vector<std::byte> A_host_data =
@@ -340,7 +240,7 @@ void check(const MmtKernel &kernel, const MNKShape &o) {
   HIP_CHECK(hipFree(shape_device_buffer));
 }
 
-void check(const MmtKernel &kernel) {
+void check(const MatvecKernel &kernel) {
   std::printf("  Checking correctness... ");
   // Test with more generic shapes than just M==N==K==2^x.
   for (MNKShape o : {MNKShape{1, 1, 1}, MNKShape{2, 1, 1}, MNKShape{1, 2, 1},
@@ -353,7 +253,7 @@ void check(const MmtKernel &kernel) {
   std::printf("OK\n");
 }
 
-void benchmark(const MmtKernel &kernel, const MNKShape &o) {
+void benchmark(const MatvecKernel &kernel, const MNKShape &o) {
   TiledMmtShape s = getTestShape(kernel, o);
   std::printf("  Benchmarking: total MxNxK=%dx%dx%d, outer MxNxK=%dx%dx%d ... ",
               s.outer.M * s.tile.M, s.outer.N * s.tile.N, s.outer.K * s.tile.K,
@@ -447,7 +347,7 @@ void benchmark(const MmtKernel &kernel, const MNKShape &o) {
   HIP_CHECK(hipFree(shape_device_buffer));
 }
 
-void test(const MmtKernel &kernel) {
+void test(const MatvecKernel &kernel) {
   char *name =
       abi::__cxa_demangle(typeid(kernel).name(), nullptr, nullptr, nullptr);
   const char *filter = getenv("FILTER");
@@ -464,13 +364,13 @@ void test(const MmtKernel &kernel) {
     check(kernel);
   }
 
-  MNKShape o = getBenchmarkMNKShape(kernel);
+  MNKShape o = getCheckProblemSize(kernel);
   benchmark(kernel, o);
 }
 
 template <Type T_A_type, Type T_B_type, Type T_C_type, int T_M_tile,
           int T_N_tile, int T_K_tile>
-class MmtKernel_generic : public MmtKernel {
+class MmtKernel_generic : public MatvecKernel {
   virtual Type A_type() const override { return T_A_type; }
   virtual Type B_type() const override { return T_B_type; }
   virtual Type C_type() const override { return T_C_type; }
@@ -519,7 +419,7 @@ class MmtKernel_generic : public MmtKernel {
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MmtKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -573,7 +473,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor : public MmtKernel {
 };
 
 class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC
-    : public MmtKernel {
+    : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -622,7 +522,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -666,7 +566,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   }
 };
 
-class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MmtKernel {
+class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -718,7 +618,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4 : public MmtKernel {
 };
 
 class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4
-    : public MmtKernel {
+    : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -796,7 +696,7 @@ class MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4
   }
 };
 
-class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
+class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -848,7 +748,7 @@ class MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   }
 };
 
-class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
+class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -907,7 +807,7 @@ class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct : public MmtKernel {
   }
 };
 
-class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MmtKernel {
+class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MatvecKernel {
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
   virtual Type C_type() const override { return Type::FP32; }
@@ -1042,7 +942,7 @@ class MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared : public MmtKernel {
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1182,7 +1082,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1337,7 +1237,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1429,7 +1329,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1523,7 +1423,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1643,7 +1543,7 @@ class
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1756,7 +1656,7 @@ class
 
 template <int MS, int NS>
 class MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
@@ -1854,7 +1754,7 @@ class MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4
 template <int MS, int NS>
 class
     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP32; }
   virtual Type B_type() const override { return Type::FP32; }
@@ -1954,7 +1854,7 @@ class
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP16; }
@@ -2046,7 +1946,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::FP16; }
@@ -2145,15 +2045,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
   }
 };
 
-template <typename A, typename B>
-__device__ __host__ std::common_type_t<A, B> ceil_div(A a, B b) {
-  return (a + b - 1) / b;
-}
 
-template <int Po2, typename A> __device__ __host__ A round_up_to_po2(A a) {
-  static_assert(Po2 > 0 && (Po2 & (Po2 - 1)) == 0);
-  return ((a - 1) | (Po2 - 1)) + 1;
-}
 
 // A simple Stream-K kernel variant of
 // MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2.
@@ -2176,7 +2068,7 @@ template <int Po2, typename A> __device__ __host__ A round_up_to_po2(A a) {
 //
 template <int MS, int NS>
 class MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   // Defining some values as constants as they will be needed in static methods
@@ -2515,7 +2407,7 @@ class MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2607,7 +2499,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2698,7 +2590,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2793,7 +2685,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }
@@ -2925,7 +2817,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload
 
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3
-    : public MmtKernel {
+    : public MatvecKernel {
   static_assert(MS >= 4 && !(MS % 4));
   static_assert(NS >= 4 && !(NS % 4));
   virtual Type A_type() const override { return Type::SI8; }

--- a/matvec.hip
+++ b/matvec.hip
@@ -15,7 +15,7 @@
 using matvec_func_t = void (*)(const void * /*A*/, const void * /*B*/,
                                void * /*C*/, int /*M*/, int /*N*/, int /*K*/);
 
-struct ProblemSize {
+struct ProblemProperties {
   Type A_type;
   Type B_type;
   Type C_type;
@@ -24,7 +24,7 @@ struct ProblemSize {
   MNKShape tile;
 };
 
-void print(const ProblemSize &problem, FILE *file = stderr) {
+void print(const ProblemProperties &problem, FILE *file = stderr) {
   fprintf(file, "A:%s, B:%s, C:%s, Total MxNxK=%dx%dx%d\n", str(problem.A_type),
           str(problem.B_type), str(problem.C_type), problem.total.M,
           problem.total.N, problem.total.K);
@@ -33,15 +33,15 @@ void print(const ProblemSize &problem, FILE *file = stderr) {
           problem.tile.N, problem.tile.K);
 }
 
-int flat_a_size(const ProblemSize &problem) {
+int flat_a_size(const ProblemProperties &problem) {
   return type_size(problem.A_type) * problem.total.M * problem.total.K;
 }
 
-int flat_b_size(const ProblemSize &problem) {
+int flat_b_size(const ProblemProperties &problem) {
   return type_size(problem.B_type) * problem.total.N * problem.total.K;
 }
 
-int flat_c_size(const ProblemSize &problem) {
+int flat_c_size(const ProblemProperties &problem) {
   return type_size(problem.C_type) * problem.total.M * problem.total.N;
 }
 
@@ -57,9 +57,9 @@ struct MatvecKernel {
   matvec_func_t matvec_func; // Device kernel pointer.
 };
 
-ProblemSize getBenchmarkProblemSize(const MatvecKernel &kernel,
+ProblemProperties getBenchmarkProblemSize(const MatvecKernel &kernel,
                                     MNKShape total) {
-  ProblemSize problem_size = {};
+  ProblemProperties problem_size = {};
   problem_size.A_type = kernel.A_type;
   problem_size.B_type = kernel.B_type;
   problem_size.C_type = kernel.C_type;
@@ -72,7 +72,7 @@ ProblemSize getBenchmarkProblemSize(const MatvecKernel &kernel,
   return problem_size;
 }
 
-ProblemSize getCheckProblemSize(const MatvecKernel &kernel) {
+ProblemProperties getCheckProblemSize(const MatvecKernel &kernel) {
   int M = getIntEnvVar("M", 4096);
   int N = getIntEnvVar("N", 1);
   int K = getIntEnvVar("K", 4096);
@@ -82,7 +82,7 @@ ProblemSize getCheckProblemSize(const MatvecKernel &kernel) {
 
 template <Type A_type, Type B_type, Type C_type>
 void checkMatvecResults(const void *A_data_void, const void *B_data_void,
-                        const void *C_data_void, const ProblemSize &problem) {
+                        const void *C_data_void, const ProblemProperties &problem) {
   if (getIntEnvVar("DEBUG", 0)) {
     fprintf(stderr, "Checking matvec result\n");
     print(problem);
@@ -130,7 +130,7 @@ void checkMatvecResults(const void *A_data_void, const void *B_data_void,
 
 void checkMatvecResults(Type A_type, Type B_type, Type C_type,
                         const void *A_data_void, const void *B_data_void,
-                        const void *C_data_void, const ProblemSize &problem) {
+                        const void *C_data_void, const ProblemProperties &problem) {
 #define HANDLE_CASE(A, B, C)                                                   \
   if (A_type == Type::A && B_type == Type::B && C_type == Type::C) {           \
     checkMatvecResults<Type::A, Type::B, Type::C>(A_data_void, B_data_void,    \
@@ -146,7 +146,7 @@ void checkMatvecResults(Type A_type, Type B_type, Type C_type,
   abort();
 }
 
-void check(const MatvecKernel &kernel, const ProblemSize &problem) {
+void check(const MatvecKernel &kernel, const ProblemProperties &problem) {
   std::minstd_rand random_engine;
   std::vector<std::byte> A_host_data =
       makeRandomBuffer(kernel.A_type, flat_a_size(problem), random_engine);
@@ -195,7 +195,7 @@ void check(const MatvecKernel &kernel) {
 }
 
 void benchmark(const MatvecKernel &kernel, MNKShape total) {
-  ProblemSize problem = getBenchmarkProblemSize(kernel, total);
+  ProblemProperties problem = getBenchmarkProblemSize(kernel, total);
   std::printf("  Benchmarking: ");
   print(problem, stdout);
 

--- a/matvec.hip
+++ b/matvec.hip
@@ -1,0 +1,358 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common.hip"
+
+#include <cstdio>
+#include <random>
+#include <vector>
+
+// Device function that implements a matrix vector multiplication over data in
+// the 'global' layout. This is not intended to work with data tiling.
+using matvec_func_t = void (*)(const void * /*A*/, const void * /*B*/,
+                               void * /*C*/, int /*M*/, int /*N*/, int /*K*/);
+
+struct ProblemSize {
+  Type A_type;
+  Type B_type;
+  Type C_type;
+  MNKShape total;
+  MNKShape outer;
+  MNKShape tile;
+};
+
+void print(const ProblemSize &problem, FILE *file = stderr) {
+  fprintf(file, "A:%s, B:%s, C:%s, Total MxNxK=%dx%dx%d\n", str(problem.A_type),
+          str(problem.B_type), str(problem.C_type), problem.total.M,
+          problem.total.N, problem.total.K);
+  fprintf(file, "\tOuter MxNxK=%dx%dx%d, Tile MxNxK=%dx%dx%d\n", problem.outer.M,
+          problem.outer.N, problem.outer.K, problem.tile.M, problem.tile.N,
+          problem.tile.K);
+}
+
+int flat_a_size(const ProblemSize& problem) {
+  return type_size(problem.A_type) * problem.total.M * problem.total.K;
+}
+
+int flat_b_size(const ProblemSize& problem) {
+  return type_size(problem.B_type) * problem.total.N * problem.total.K;
+}
+
+int flat_c_size(const ProblemSize& problem) {
+  return type_size(problem.C_type) * problem.total.M * problem.total.N;
+}
+
+struct MatvecKernel {
+  const char *name; // Kernel name.
+  Type A_type;      // Element type of the LHS matrix.
+  Type B_type;      // Element type of the RHS matrix.
+  Type C_type;      // Element type of the result matrix.
+  int M_tile;       // M-dimension tile size (rows of accumulator).
+  int N_tile;       // N-dimension tile size (columns of accumulator).
+  int K_tile;       // K-dimension tile size (reduction dimension).
+  int num_threads;  // Number of threads that the kernel requires running on.
+  matvec_func_t matvec_func; // Device kernel pointer.
+};
+
+ProblemSize getBenchmarkProblemSize(const MatvecKernel &kernel,
+                                    MNKShape total) {
+  ProblemSize problem_size = {};
+  problem_size.A_type = kernel.A_type;
+  problem_size.B_type = kernel.B_type;
+  problem_size.C_type = kernel.C_type;
+  problem_size.tile = {kernel.M_tile, kernel.N_tile, kernel.K_tile};
+
+  problem_size.total = total;
+  problem_size.outer.M = ceil_div(total.M, kernel.M_tile);
+  problem_size.outer.N = ceil_div(total.N, kernel.N_tile);
+  problem_size.outer.K = ceil_div(total.K, kernel.K_tile);
+  return problem_size;
+}
+
+ProblemSize getCheckProblemSize(const MatvecKernel &kernel) {
+  int M = getIntEnvVar("M", 4096);
+  int N = getIntEnvVar("N", 1);
+  int K = getIntEnvVar("K", 4096);
+  MNKShape total = {M, N, K};
+  return getBenchmarkProblemSize(kernel, total);
+}
+
+template <Type A_type, Type B_type, Type C_type>
+void checkMatvecResults(const void *A_data_void, const void *B_data_void,
+                        const void *C_data_void, const ProblemSize &problem) {
+  if (getIntEnvVar("DEBUG", 0)) {
+    fprintf(stderr, "Checking matvec result\n");
+    print(problem);
+  }
+  using TA = CType<A_type>;
+  using TB = CType<B_type>;
+  using TC = CType<C_type>;
+  const TA *A_data = static_cast<const TA *>(A_data_void);
+  const TB *B_data = static_cast<const TB *>(B_data_void);
+  const TC *C_data = static_cast<const TC *>(C_data_void);
+  // This reference code is slow. To make the checks not too slow on
+  // large matmuls, we only check the 9 corner/middle tiles.
+  for (int m_outer : {0, problem.outer.M / 2, problem.outer.M - 1}) {
+    for (int n_outer : {0, problem.outer.N / 2, problem.outer.N - 1}) {
+      for (int m_tile = 0; m_tile < problem.tile.M; ++m_tile) {
+        for (int n_tile = 0; n_tile < problem.tile.N; ++n_tile) {
+          int global_m = m_outer * problem.tile.M + m_tile;
+          int global_n = n_outer * problem.tile.N + n_tile;
+          TC c = {0};
+          for (int k_outer = 0; k_outer < problem.outer.K; ++k_outer) {
+            for (int k_tile = 0; k_tile < problem.tile.K; ++k_tile) {
+              int global_k = k_outer * problem.tile.K + k_tile;
+              TA a = A_data[global_m * problem.total.K + global_k];
+              TB b = B_data[global_n * problem.total.K + global_k];
+              c += static_cast<TC>(a) * static_cast<TC>(b);
+            }
+          }
+          TC expected = c;
+          TC actual =
+              C_data[global_m * problem.total.N + global_n];
+          if (actual != expected) {
+            fprintf(stderr,
+                    "matmul numerical error: actual(%g) != "
+                    "expected(%g), at m_outer=%d n_outer=%d m_tile=%d "
+                    "n_tile=%d, at %s:%d. Note: outer MxNxK = %dx%dx%d\n",
+                    static_cast<float>(actual), static_cast<float>(expected),
+                    m_outer, n_outer, m_tile, n_tile, __FILE__, __LINE__,
+                    problem.outer.M, problem.outer.N, problem.outer.K);
+            abort();
+          }
+        }
+      }
+    }
+  }
+}
+
+void checkMatvecResults(Type A_type, Type B_type, Type C_type,
+                        const void *A_data_void, const void *B_data_void,
+                        const void *C_data_void, const ProblemSize &problem) {
+#define HANDLE_CASE(A, B, C)                                                   \
+  if (A_type == Type::A && B_type == Type::B && C_type == Type::C) {           \
+    checkMatvecResults<Type::A, Type::B, Type::C>(A_data_void, B_data_void,    \
+                                                  C_data_void, problem);       \
+    return;                                                                    \
+  }
+  HANDLE_CASE(FP32, FP32, FP32)
+  HANDLE_CASE(FP16, FP16, FP32)
+  HANDLE_CASE(SI8, SI8, SI32)
+#undef HANDLE_CASE
+
+  fprintf(stderr, "%s:%d: unhandled types\n", __FILE__, __LINE__);
+  abort();
+}
+
+void check(const MatvecKernel &kernel, const ProblemSize &problem) {
+  std::minstd_rand random_engine;
+  std::vector<std::byte> A_host_data =
+      makeRandomBuffer(kernel.A_type, flat_a_size(problem), random_engine);
+  std::vector<std::byte> B_host_data =
+      makeRandomBuffer(kernel.B_type, flat_b_size(problem), random_engine);
+  std::vector<std::byte> C_host_data =
+      makeRandomBuffer(kernel.C_type, flat_c_size(problem), random_engine);
+
+  void *A_device_buffer = nullptr;
+  void *B_device_buffer = nullptr;
+  void *C_device_buffer = nullptr;
+  HIP_CHECK(hipMalloc(&A_device_buffer, A_host_data.size()));
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMalloc(&B_device_buffer, B_host_data.size()));
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMalloc(&C_device_buffer, C_host_data.size()));
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(A_device_buffer, A_host_data.data(), A_host_data.size(),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(B_device_buffer, B_host_data.data(), B_host_data.size(),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(C_device_buffer, C_host_data.data(), C_host_data.size(),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipGetLastError());
+
+  const dim3 grid_dim(problem.outer.M, problem.outer.N);
+  const dim3 block_dim(kernel.num_threads);
+  HIP_CHECK(hipGetLastError());
+  kernel.matvec_func<<<grid_dim, block_dim, 0, hipStreamDefault>>>(
+      A_device_buffer, B_device_buffer, C_device_buffer, problem.total.M,
+      problem.total.N, problem.total.K);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(C_host_data.data(), C_device_buffer, C_host_data.size(),
+                      hipMemcpyDeviceToHost));
+  checkMatvecResults(kernel.A_type, kernel.B_type, kernel.C_type,
+                     A_host_data.data(), B_host_data.data(), C_host_data.data(),
+                     problem);
+
+  HIP_CHECK(hipFree(A_device_buffer));
+  HIP_CHECK(hipFree(B_device_buffer));
+  HIP_CHECK(hipFree(C_device_buffer));
+}
+
+void check(const MatvecKernel &kernel) {
+  check(kernel, getCheckProblemSize(kernel));
+}
+
+void benchmark(const MatvecKernel &kernel, MNKShape total) {
+  ProblemSize problem = getBenchmarkProblemSize(kernel, total);
+  std::printf("  Benchmarking: ");
+  print(problem, stdout);
+
+  std::minstd_rand random_engine;
+  std::vector<std::byte> A_host_data =
+      makeRandomBuffer(kernel.A_type, flat_a_size(problem), random_engine);
+  std::vector<std::byte> B_host_data =
+      makeRandomBuffer(kernel.B_type, flat_b_size(problem), random_engine);
+  std::vector<std::byte> C_host_data =
+      makeRandomBuffer(kernel.C_type, flat_c_size(problem), random_engine);
+
+  void *A_device_buffer{};
+  void *B_device_buffer{};
+  void *C_device_buffer{};
+  HIP_CHECK(hipMalloc(&A_device_buffer, A_host_data.size()));
+  HIP_CHECK(hipMalloc(&B_device_buffer, B_host_data.size()));
+  HIP_CHECK(hipMalloc(&C_device_buffer, C_host_data.size()));
+
+  HIP_CHECK(hipMemcpy(A_device_buffer, A_host_data.data(), A_host_data.size(),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(B_device_buffer, B_host_data.data(), B_host_data.size(),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(C_device_buffer, C_host_data.data(), C_host_data.size(),
+                      hipMemcpyHostToDevice));
+
+  const dim3 grid_dim(problem.outer.M, problem.outer.N);
+  const dim3 block_dim(kernel.num_threads);
+
+  hipEvent_t start, stop;
+  HIP_CHECK(hipEventCreate(&start));
+  HIP_CHECK(hipEventCreate(&stop));
+  float elapsed_ms{};
+  float min_elapsed_ms = getIntEnvVar("BENCHMARK_MIN_MS", 100);
+  int fixed_iterations = getIntEnvVar("FIXED_ITERATIONS", 0);
+  int iterations = fixed_iterations ? fixed_iterations : 1;
+  while (true) {
+    HIP_CHECK(hipEventRecord(start, hipStreamDefault));
+    for (int b = 0; b < iterations; ++b) {
+      kernel.matvec_func<<<grid_dim, block_dim, 0, hipStreamDefault>>>(
+          A_device_buffer, B_device_buffer, C_device_buffer, problem.total.M,
+          problem.total.N, problem.total.K);
+    }
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipEventRecord(stop, hipStreamDefault));
+    HIP_CHECK(hipEventSynchronize(stop));
+    HIP_CHECK(hipEventElapsedTime(&elapsed_ms, start, stop));
+    if (elapsed_ms >= min_elapsed_ms || fixed_iterations) {
+      break;
+    }
+    if (iterations > (1 << 20)) {
+      fprintf(stderr, "Vacuous kernel? Only taking %g ms at iterations=%d.\n",
+              elapsed_ms, iterations);
+      abort();
+    }
+    iterations *= 2;
+  }
+
+  HIP_CHECK(hipEventDestroy(start));
+  HIP_CHECK(hipEventDestroy(stop));
+  HIP_CHECK(hipFree(A_device_buffer));
+  HIP_CHECK(hipFree(B_device_buffer));
+  HIP_CHECK(hipFree(C_device_buffer));
+
+  // Calculate the actual amount of memory read during the calculation, taking
+  // into account the tile sizes.
+  float A_element_bytes = type_size(kernel.A_type);
+  float B_element_bytes = type_size(kernel.B_type);
+  float A_bytes = A_element_bytes * problem.total.M * problem.total.K;
+  float B_bytes = B_element_bytes * problem.total.N * problem.total.K;
+  float kernel_bytes_read = A_bytes + B_bytes;
+
+  float kernel_ms = elapsed_ms / iterations;
+  float kernel_ops = 2.f * problem.total.M * problem.total.N * problem.total.K;
+  float kernel_ops_per_s = 1000.f * kernel_ops / kernel_ms;
+  float kernel_bytes_read_per_s = 1000.f * kernel_bytes_read / kernel_ms;
+  std::printf(
+      "\tRead %.4g TB/s, %.4g Tflop/s, latency %.2g ms, iterations=%d\n",
+      1.e-12f * kernel_ops_per_s, 1e-12f * kernel_bytes_read_per_s, kernel_ms,
+      iterations);
+}
+
+struct NaiveMatmulKernel : MatvecKernel {
+  using TA = float;
+  using TB = float;
+  using TC = float;
+  static constexpr int T_M_tile = 64; // One subgroup.
+  static constexpr int T_N_tile = 1;
+  static constexpr int T_K_tile = 4; // dword_x4.
+
+  NaiveMatmulKernel() {
+    name = __FUNCTION__;
+    A_type = Type::FP32;
+    B_type = Type::FP32;
+    C_type = Type::FP32;
+    M_tile = T_M_tile;
+    N_tile = T_N_tile;
+    K_tile = T_K_tile;
+    num_threads = M_tile * N_tile;
+    matvec_func = run;
+  }
+
+  __global__ static void run(const void *A_data, const void *B_data,
+                             void *C_data, int M, int N, int K) {
+    int m_outer = blockIdx.x;
+    int n_outer = blockIdx.y;
+    int m_tile = threadIdx.x / T_N_tile;
+    int n_tile = threadIdx.x % T_N_tile;
+
+    int K_outer = ceil_div(K, T_K_tile);
+
+    int global_m = m_outer * T_M_tile + m_tile;
+    int global_n = n_outer * T_N_tile + n_tile;
+    if (global_m >= M || global_n >= N)
+      return;
+
+    TC c = {0};
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      for (int k_tile = 0; k_tile < T_K_tile; ++k_tile) {
+        int global_k = k_outer * T_K_tile + k_tile;
+        if (global_k >= K) {
+          break;
+        }
+
+        TA a = static_cast<const TA *>(A_data)[global_m * K + global_k];
+        TB b = static_cast<const TB *>(B_data)[global_n * K + global_k];
+        c += static_cast<TC>(a) * static_cast<TC>(b);
+      }
+    }
+
+    static_cast<TC *>(C_data)[global_m * N + global_n] = c;
+  }
+};
+
+void test(const MatvecKernel &kernel) {
+  const char *filter = getenv("FILTER");
+  if (filter && !strstr(kernel.name, filter)) {
+    return;
+  }
+  std::printf("%s: A:%s, B:%s, C:%s, tile MxNxK=%dx%dx%d, num_threads=%d\n",
+              kernel.name, str(kernel.A_type), str(kernel.B_type),
+              str(kernel.C_type), kernel.M_tile, kernel.N_tile, kernel.K_tile,
+              kernel.num_threads);
+
+  if (!getenv("SKIP_CHECK")) {
+    check(kernel);
+  }
+
+  MNKShape test_shapes[] = {{14336, 1, 4096},
+                            {4096, 1, 14336},
+                            {4096, 1, 4096},
+                            {1024, 1, 4096}};
+  for (MNKShape shape : test_shapes) {
+    benchmark(kernel, shape);
+  }
+}
+
+int main() {
+  test(NaiveMatmulKernel{});
+}

--- a/matvec.hip
+++ b/matvec.hip
@@ -28,20 +28,20 @@ void print(const ProblemSize &problem, FILE *file = stderr) {
   fprintf(file, "A:%s, B:%s, C:%s, Total MxNxK=%dx%dx%d\n", str(problem.A_type),
           str(problem.B_type), str(problem.C_type), problem.total.M,
           problem.total.N, problem.total.K);
-  fprintf(file, "\tOuter MxNxK=%dx%dx%d, Tile MxNxK=%dx%dx%d\n", problem.outer.M,
-          problem.outer.N, problem.outer.K, problem.tile.M, problem.tile.N,
-          problem.tile.K);
+  fprintf(file, "\tOuter MxNxK=%dx%dx%d, Tile MxNxK=%dx%dx%d\n",
+          problem.outer.M, problem.outer.N, problem.outer.K, problem.tile.M,
+          problem.tile.N, problem.tile.K);
 }
 
-int flat_a_size(const ProblemSize& problem) {
+int flat_a_size(const ProblemSize &problem) {
   return type_size(problem.A_type) * problem.total.M * problem.total.K;
 }
 
-int flat_b_size(const ProblemSize& problem) {
+int flat_b_size(const ProblemSize &problem) {
   return type_size(problem.B_type) * problem.total.N * problem.total.K;
 }
 
-int flat_c_size(const ProblemSize& problem) {
+int flat_c_size(const ProblemSize &problem) {
   return type_size(problem.C_type) * problem.total.M * problem.total.N;
 }
 
@@ -111,8 +111,7 @@ void checkMatvecResults(const void *A_data_void, const void *B_data_void,
             }
           }
           TC expected = c;
-          TC actual =
-              C_data[global_m * problem.total.N + global_n];
+          TC actual = C_data[global_m * problem.total.N + global_n];
           if (actual != expected) {
             fprintf(stderr,
                     "matmul numerical error: actual(%g) != "
@@ -344,15 +343,11 @@ void test(const MatvecKernel &kernel) {
     check(kernel);
   }
 
-  MNKShape test_shapes[] = {{14336, 1, 4096},
-                            {4096, 1, 14336},
-                            {4096, 1, 4096},
-                            {1024, 1, 4096}};
+  MNKShape test_shapes[] = {
+      {14336, 1, 4096}, {4096, 1, 14336}, {4096, 1, 4096}, {1024, 1, 4096}};
   for (MNKShape shape : test_shapes) {
     benchmark(kernel, shape);
   }
 }
 
-int main() {
-  test(NaiveMatmulKernel{});
-}
+int main() { test(NaiveMatmulKernel{}); }


### PR DESCRIPTION
This is a reference matvec implementation only. The common code shared
with the data-tiled mmt is moved to `common.hip`.

The matvec scaffolding is based off the mmt code, but without data
tiling and much of the dynamism (virtual functions / RTTI).