### PR TITLE
StreamK variant with wait-free binary tree reduction with deterministic results.

### DIFF
--- a/matmul.hip
+++ b/matmul.hip
@@ -2200,7 +2200,7 @@ class MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
     int total_iters = total_tiles * iters_per_tile;
     int workgroup_count = get_workgroup_count(outer);
     int workgroup = blockIdx.x;
-    const int NUM_XCDS = 38;
+    const int NUM_XCDS = 8;
     if (workgroup_count == MaxWorkgroups) {
       workgroup = (workgroup % NUM_XCDS) * (workgroup_count / NUM_XCDS) + (workgroup / NUM_XCDS);
     }
@@ -2577,7 +2577,7 @@ class MmtKernel_StreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2
     int total_iters = total_tiles * iters_per_tile;
     int workgroup_count = get_workgroup_count(outer);
     int workgroup = blockIdx.x;
-    const int NUM_XCDS = 38;
+    const int NUM_XCDS = 8;
     if (workgroup_count == MaxWorkgroups) {
       workgroup = (workgroup % NUM_XCDS) * (workgroup_count / NUM_XCDS) + (workgroup / NUM_XCDS);
     }


### PR DESCRIPTION
This adds a StreamK kernel where the final reduction is distributed over as many workgroups as possible by a binary tree reduction.

This is still wait-free and still produces deterministic results, although the results differ from those produced by a linear reduction.

Performance is anywhere between 0.5x and 1.1x of the linear-reduction StreamK kernel depending on the shape. That is hard to interpret though as that is only a matmul microbenchmark, the inner MAC loop is not optimized, etc. The value of this kernel as it stands is more as a proof of concept.