### PR TITLE
Add skinny gemm using sparse trick kernel

### DIFF
--- a/matmul.hip
+++ b/matmul.hip
@@ -3358,6 +3358,151 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
   }
 };
 
+// M-padded MFMA kernel for skinny GEMMs (M=8->16).
+// Uses the dense mfma_i32_16x16x32_i8 instruction with zero-padding
+// on the A operand for lanes corresponding to M-rows 8-15.
+// This serves as a benchmark comparison against the smfmac sparse
+// trick kernel below, which achieves the same M=8 matmul using
+// smfmac_i32_16x16x64_i8.
+//
+// Lane mapping for mfma_i32_16x16x32_i8:
+//   A operand: lane%16 = M-row (0-15), lane/16 = K-group (0-3), 8 i8 per lane
+//   B operand: lane%16 = N-col (0-15), lane/16 = K-group (0-3), 8 i8 per lane
+//   Output: d[p] = C[4*(lane/16) + p][lane%16], p=0..3
+//
+// For M=8: lanes with lane%16 >= 8 feed A=0 (zero-padding).
+// Output rows 0-7 are real (lane/16 < 2), rows 8-15 are discarded.
+// Since mfma processes K=32 vs smfmac's K=64, the inner loop runs
+// KS*2 iterations (nested kb=0..KS-1, kh=0..1).
+template <int NS, int KS>
+class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  virtual Type A_type() const override { return Type::SI8; }
+  virtual Type B_type() const override { return Type::SI8; }
+  virtual Type C_type() const override { return Type::SI32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 64; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 64) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 1024) + n_col * (KS * 64) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using int8x8_t = int64_t;
+    using int32x4_t = __attribute__((__vector_size__(16))) int32_t;
+    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
+
+    int32x4_t acc[NS / 4] = {{0}};
+
+    const int tid = threadIdx.x;
+    const int lane = tid % 64;
+    const int warp = tid / 64;
+
+    // A tile: 8 rows * KS*64 bytes, stored as i8x16 elements
+    // B tile: NS n-blocks * 16 n-cols * KS*64 k-bytes, as i8x16 elements
+    constexpr int A_TILE_VEC16 = 8 * KS * 4;
+    constexpr int B_TILE_VEC16 = NS * KS * 64;
+
+    const auto *A_base = static_cast<const i8x16 *>(A_data) +
+                         blockIdx.x * K_outer * A_TILE_VEC16;
+    const auto *B_base = static_cast<const i8x16 *>(B_data) +
+                         blockIdx.y * K_outer * B_TILE_VEC16;
+    const auto *B_global_ptr = B_base + tid;
+
+    __shared__ i8x16 A_smem[A_TILE_VEC16];
+    __shared__ i8x16 B_smem[B_TILE_VEC16];
+    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
+
+    // Lane-to-data mapping for mfma_i32_16x16x32_i8
+    const int a_m_row = lane % 16;
+    const int a_k_group = lane / 16;
+    const int b_n_col = lane % 16;
+    const int b_k_group = lane / 16;
+
+    // Pre-compute A LDS base offset (only dereferenced when a_m_row < 8)
+    const int a_lds_base = a_m_row * (KS * 64) + a_k_group * 8;
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      if (tid < A_TILE_VEC16) {
+        const i8x16 *A_ptr = A_base + k_outer * A_TILE_VEC16;
+        A_smem[tid] = A_ptr[tid];
+      }
+
+      for (int i = 0; i < B_TILE_VEC16; i += 256) {
+        B_smem[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_TILE_VEC16;
+      __syncthreads();
+
+      for (int kb = 0; kb < KS; ++kb) {
+        for (int kh = 0; kh < 2; ++kh) {
+          // Load A: zero-pad for M-rows >= 8 (padding region)
+          int8x8_t a_reg = (a_m_row < 8)
+              ? *reinterpret_cast<int8x8_t *>(
+                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
+              : 0;
+
+          for (int j = 0; j < NS / 4; ++j) {
+            int n_block = j * 4 + warp;
+
+            auto *b_ptr = reinterpret_cast<int8x8_t *>(
+                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
+                b_n_col * (KS * 64) + kb * 64 + kh * 32 + b_k_group * 8);
+            int8x8_t b_reg = *b_ptr;
+
+            acc[j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
+                a_reg, b_reg, acc[j], 0, 0, 0);
+          }
+        }
+        __syncthreads();
+      }
+    }
+
+    // Output: d[p] = C[4*(lane/16) + p][lane%16]
+    // Only lane/16 < 2 (rows 0-7) contain real results.
+    constexpr int N_STRIDE = NS * 16;
+    constexpr int TILE_ELEMS = 8 * N_STRIDE;
+    const int g = lane / 16;
+    const int n_col_out = lane % 16;
+
+    int32_t *C_tile = static_cast<int32_t *>(C_data) +
+                      TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
+
+    if (g < 2) {
+      const int m_base = g * 4;
+      for (int j = 0; j < NS / 4; ++j) {
+        const int n = (j * 4 + warp) * 16 + n_col_out;
+        auto *d = reinterpret_cast<int32_t *>(&acc[j]);
+        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
+        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
+        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
+        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
+      }
+    }
+  }
+};
+
 // The `smfmac` kernels are designed for skinny GEMMs (M=8)
 // by using sparse MFMA intrinsics to perform a fully dense
 // matmul. SMFMAC takes a 4:2-sparse operand A (where we
@@ -4124,6 +4269,12 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 2>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<16, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 4>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 8>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 4>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<16, 2>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 2>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 8>());

--- a/matmul.hip
+++ b/matmul.hip
@@ -3328,7 +3328,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
     __shared__ int8x8_t B_shared[B_tile_size_in_vec8];
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      for (int i = 0; i < A_tile_size_in_vec8; i += 256) { 
+      for (int i = 0; i < A_tile_size_in_vec8; i += 256) {
         A_shared[i + tid] = A_global_ptr[i];
       }
       for (int j = 0; j < B_tile_size_in_vec8; j += 256) {
@@ -3338,8 +3338,8 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
       B_global_ptr += B_tile_size_in_vec8;
       __syncthreads();
 
-      for (int i = 0; i < MS; ++i) { 
-        for (int j = 0; j < NS / 4; ++j) { 
+      for (int i = 0; i < MS; ++i) {
+        for (int j = 0; j < NS / 4; ++j) {
           acc[i][j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
               A_shared[64 * i + (tid % 64)], B_shared[256 * j + tid], acc[i][j],
               0, 0, 0);

--- a/matmul.hip
+++ b/matmul.hip
@@ -3472,7 +3472,6 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
         B_smem[i + tid] = B_global_ptr[i];
       }
       B_global_ptr += B_TILE_VEC16;
-
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {

--- a/matmul.hip
+++ b/matmul.hip
@@ -3532,6 +3532,166 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
   }
 };
 
+template <int NS, int KS>
+class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  static constexpr int SPARSITY_EVEN = 0x00000044;
+  static constexpr int SPARSITY_ODD = 0x000000EE;
+  static constexpr int NB_BANKS = 32;
+
+  virtual Type A_type() const override { return Type::FP16; }
+  virtual Type B_type() const override { return Type::FP16; }
+  virtual Type C_type() const override { return Type::FP32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 32; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 32) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 512) + n_col * (KS * 32) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using f16x4 =
+        __attribute__((__vector_size__(4 * sizeof(_Float16)))) _Float16;
+    using f16x8 =
+        __attribute__((__vector_size__(8 * sizeof(_Float16)))) _Float16;
+    using f32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
+    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
+
+    union {
+      f16x4 vec;
+      int32_t i32[2];
+    } a_reg;
+
+    f32x4 acc[NS / 4] = {{0}};
+
+    int m_outer = blockIdx.x;
+    int n_outer = blockIdx.y;
+    int tid = threadIdx.x;
+    int lane_id = tid % 64;
+    int warp_id = tid / 64;
+
+    constexpr int A_tile_size_in_vec16 = 8 * KS * 4;
+    constexpr int B_tile_size_in_vec16 = NS * KS * 64;
+
+    const i8x16 *A_global = static_cast<const i8x16 *>(A_data) +
+                            m_outer * K_outer * A_tile_size_in_vec16;
+    const i8x16 *B_global = static_cast<const i8x16 *>(B_data) +
+                            n_outer * K_outer * B_tile_size_in_vec16;
+    const i8x16 *B_global_ptr = B_global + tid;
+
+    __shared__ int8_t A_shared[KS * 512];
+    __shared__ i8x16 B_shared[B_tile_size_in_vec16];
+
+    int a_row_prod = tid / (KS * 4);
+    int a_k_chunk = tid % (KS * 4);
+    int a_bank = a_k_chunk / 4;
+    int k_chunk_in_bank = a_k_chunk % 4;
+    int a_col_prod = a_row_prod + k_chunk_in_bank * 8;
+
+    int32_t *A_lds = reinterpret_cast<int32_t *>(A_shared);
+
+    int a_m_row = (lane_id % 16) / 2;
+    int a_is_odd = lane_id % 2;
+    int a_k_range = lane_id / 16;
+    int a_col_cons = a_m_row + a_k_range * 8;
+
+    int n_col = lane_id % 16;
+    int k_slice = lane_id / 16;
+
+    int sparsity_idx = (lane_id & 1) ? SPARSITY_ODD : SPARSITY_EVEN;
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      const i8x16 *A_tile_base = A_global + k_outer * A_tile_size_in_vec16;
+
+      if (tid < A_tile_size_in_vec16) {
+        auto global_idx = a_row_prod * (KS * 4) + a_k_chunk;
+        i8x16 a_loaded = A_tile_base[a_row_prod * (KS * 4) + a_k_chunk];
+        int32_t reg0 = reinterpret_cast<int32_t *>(&a_loaded)[0]; // [K0, K1]
+        int32_t reg1 = reinterpret_cast<int32_t *>(&a_loaded)[1]; // [K2, K3]
+        int32_t reg2 = reinterpret_cast<int32_t *>(&a_loaded)[2]; // [K4, K5]
+        int32_t reg3 = reinterpret_cast<int32_t *>(&a_loaded)[3]; // [K6, K7]
+
+        int32_t *bank_base = A_lds + a_bank * 128;
+        bank_base[0 * NB_BANKS + a_col_prod] = reg0; // Line 0: EVEN [K0, K1]
+        bank_base[1 * NB_BANKS + a_col_prod] = reg2; // Line 1: EVEN [K4, K5]
+        bank_base[2 * NB_BANKS + a_col_prod] = reg1; // Line 2: ODD  [K2, K3]
+        bank_base[3 * NB_BANKS + a_col_prod] = reg3; // Line 3: ODD  [K6, K7]
+      }
+
+      for (int i = 0; i < B_tile_size_in_vec16; i += 256) {
+        B_shared[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_tile_size_in_vec16;
+      __syncthreads();
+
+      for (int k_bank = 0; k_bank < KS; ++k_bank) {
+        int8_t *a_cons =
+            A_shared + k_bank * 512 + a_col_cons * 4 + a_is_odd * 256;
+        int32_t *a_ptr = reinterpret_cast<int32_t *>(a_cons);
+        a_reg.i32[0] = a_ptr[0];
+        a_reg.i32[1] = a_ptr[NB_BANKS];
+
+        for (int j = 0; j < NS / 4; ++j) {
+          int n_block = j * 4 + warp_id;
+
+          int8_t *b_cons = reinterpret_cast<int8_t *>(B_shared) +
+                           n_block * (KS * 1024) + n_col * (KS * 64) +
+                           k_bank * 64 + k_slice * 16;
+          f16x8 b_reg = *reinterpret_cast<f16x8 *>(b_cons);
+
+          acc[j] = __builtin_amdgcn_smfmac_f32_16x16x32_f16(
+              a_reg.vec, b_reg, acc[j], sparsity_idx, 0, 0);
+        }
+      }
+    }
+
+    for (int j = 0; j < NS / 4; ++j) {
+      float *regD = reinterpret_cast<float *>(&acc[j]);
+      regD[0] = regD[0] + regD[1];
+      regD[1] = regD[2] + regD[3];
+    }
+
+    constexpr int N_stride = NS * 16;
+    int m_pair = lane_id / 16;
+    int m0 = m_pair * 2;
+    int m1 = m_pair * 2 + 1;
+
+    constexpr int tile_size = 8 * NS * 16;
+    float *C_tile = static_cast<float *>(C_data) +
+                    tile_size * (N_outer * m_outer + n_outer);
+
+    for (int j = 0; j < NS / 4; ++j) {
+      int n_block = j * 4 + warp_id;
+      int n = n_block * 16 + n_col;
+
+      float *regD = reinterpret_cast<float *>(&acc[j]);
+      C_tile[m0 * N_stride + n] = regD[0];
+      C_tile[m1 * N_stride + n] = regD[1];
+    }
+  }
+};
+
 template <int MS, int NS>
 class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2
     : public MmtKernel {
@@ -3963,6 +4123,12 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 2>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<16, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
 
   std::printf("\n\n\nStream-K experiments:\n\n");
   test(

--- a/matmul.hip
+++ b/matmul.hip
@@ -3358,303 +3358,6 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
   }
 };
 
-// M-padded MFMA kernel for skinny GEMMs (M=8->16).
-// Uses the dense mfma_i32_16x16x32_i8 instruction with zero-padding
-// on the A operand for lanes corresponding to M-rows 8-15.
-// This serves as a benchmark comparison against the smfmac sparse
-// trick kernel below, which achieves the same M=8 matmul using
-// smfmac_i32_16x16x64_i8.
-//
-// Lane mapping for mfma_i32_16x16x32_i8:
-//   A operand: lane%16 = M-row (0-15), lane/16 = K-group (0-3), 8 i8 per lane
-//   B operand: lane%16 = N-col (0-15), lane/16 = K-group (0-3), 8 i8 per lane
-//   Output: d[p] = C[4*(lane/16) + p][lane%16], p=0..3
-//
-// For M=8: lanes with lane%16 >= 8 feed A=0 (zero-padding).
-// Output rows 0-7 are real (lane/16 < 2), rows 8-15 are discarded.
-// Since mfma processes K=32 vs smfmac's K=64, the inner loop runs
-// KS*2 iterations (nested kb=0..KS-1, kh=0..1).
-template <int NS, int KS>
-class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
-    : public MmtKernel {
-  static_assert(NS >= 4 && !(NS % 4));
-  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
-
-  virtual Type A_type() const override { return Type::SI8; }
-  virtual Type B_type() const override { return Type::SI8; }
-  virtual Type C_type() const override { return Type::SI32; }
-  virtual int M_tile() const override { return 8; }
-  virtual int N_tile() const override { return NS * 16; }
-  virtual int K_tile() const override { return KS * 64; }
-
-  virtual tile_layout_func_t A_tile_layout() const override {
-    return [](int m, int k) { return m * (KS * 64) + k; };
-  }
-
-  virtual tile_layout_func_t B_tile_layout() const override {
-    return [](int n, int k) {
-      int n_block = n / 16;
-      int n_col = n % 16;
-      return n_block * (KS * 1024) + n_col * (KS * 64) + k;
-    };
-  }
-
-  virtual tile_layout_func_t C_tile_layout() const override {
-    return [](int m, int n) { return m * (NS * 16) + n; };
-  }
-
-  virtual int num_threads() const override { return 256; }
-  virtual mmt_func_t mmt_func() const override { return run; };
-
-  __global__ __launch_bounds__(256) static void run(
-      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
-      int /*M_outer*/, int N_outer, int K_outer) {
-    using int8x8_t = int64_t;
-    using int32x4_t = __attribute__((__vector_size__(16))) int32_t;
-    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
-
-    int32x4_t acc[NS / 4] = {{0}};
-
-    const int tid = threadIdx.x;
-    const int lane = tid % 64;
-    const int warp = tid / 64;
-
-    // A tile: 8 rows * KS*64 bytes, stored as i8x16 elements
-    // B tile: NS n-blocks * 16 n-cols * KS*64 k-bytes, as i8x16 elements
-    constexpr int A_TILE_VEC16 = 8 * KS * 4;
-    constexpr int B_TILE_VEC16 = NS * KS * 64;
-
-    const auto *A_base = static_cast<const i8x16 *>(A_data) +
-                         blockIdx.x * K_outer * A_TILE_VEC16;
-    const auto *B_base = static_cast<const i8x16 *>(B_data) +
-                         blockIdx.y * K_outer * B_TILE_VEC16;
-    const auto *B_global_ptr = B_base + tid;
-
-    __shared__ i8x16 A_smem[A_TILE_VEC16];
-    __shared__ i8x16 B_smem[B_TILE_VEC16];
-    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
-
-    // Lane-to-data mapping for mfma_i32_16x16x32_i8
-    const int a_m_row = lane % 16;
-    const int a_k_group = lane / 16;
-    const int b_n_col = lane % 16;
-    const int b_k_group = lane / 16;
-
-    // Pre-compute A LDS base offset (only dereferenced when a_m_row < 8)
-    const int a_lds_base = a_m_row * (KS * 64) + a_k_group * 8;
-
-    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      if (tid < A_TILE_VEC16) {
-        const i8x16 *A_ptr = A_base + k_outer * A_TILE_VEC16;
-        A_smem[tid] = A_ptr[tid];
-      }
-
-      for (int i = 0; i < B_TILE_VEC16; i += 256) {
-        B_smem[i + tid] = B_global_ptr[i];
-      }
-      B_global_ptr += B_TILE_VEC16;
-      __syncthreads();
-
-      for (int kb = 0; kb < KS; ++kb) {
-        for (int kh = 0; kh < 2; ++kh) {
-          // Load A: zero-pad for M-rows >= 8 (padding region)
-          int8x8_t a_reg = (a_m_row < 8)
-              ? *reinterpret_cast<int8x8_t *>(
-                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
-              : 0;
-
-          for (int j = 0; j < NS / 4; ++j) {
-            int n_block = j * 4 + warp;
-
-            auto *b_ptr = reinterpret_cast<int8x8_t *>(
-                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
-                b_n_col * (KS * 64) + kb * 64 + kh * 32 + b_k_group * 8);
-            int8x8_t b_reg = *b_ptr;
-
-            acc[j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
-                a_reg, b_reg, acc[j], 0, 0, 0);
-          }
-        }
-        __syncthreads();
-      }
-    }
-
-    // Output: d[p] = C[4*(lane/16) + p][lane%16]
-    // Only lane/16 < 2 (rows 0-7) contain real results.
-    constexpr int N_STRIDE = NS * 16;
-    constexpr int TILE_ELEMS = 8 * N_STRIDE;
-    const int g = lane / 16;
-    const int n_col_out = lane % 16;
-
-    int32_t *C_tile = static_cast<int32_t *>(C_data) +
-                      TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
-
-    if (g < 2) {
-      const int m_base = g * 4;
-      for (int j = 0; j < NS / 4; ++j) {
-        const int n = (j * 4 + warp) * 16 + n_col_out;
-        auto *d = reinterpret_cast<int32_t *>(&acc[j]);
-        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
-        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
-        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
-        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
-      }
-    }
-  }
-};
-
-// FP16 variant of the M-padded MFMA kernel for skinny GEMMs (M=8->16).
-// Uses the dense mfma_f32_16x16x16_f16 instruction with zero-padding
-// on the A operand for lanes corresponding to M-rows 8-15.
-// Companion to the i8 zeropad kernel above; benchmarks the overhead of
-// M-padding with dense mfma vs the sparse trick with smfmac for FP16.
-//
-// Lane mapping for mfma_f32_16x16x16_f16:
-//   A operand: lane%16 = M-row (0-15), lane/16 = K-group (0-3), 4 f16 per lane
-//   B operand: lane%16 = N-col (0-15), lane/16 = K-group (0-3), 4 f16 per lane
-//   Output: d[p] = C[4*(lane/16) + p][lane%16], p=0..3
-//
-// For M=8: lanes with lane%16 >= 8 feed A=0 (zero-padding).
-// Output rows 0-7 are real (lane/16 < 2), rows 8-15 are discarded.
-// Since mfma processes K=16 vs smfmac's K=32, the inner loop runs
-// KS*2 iterations (nested kb=0..KS-1, kh=0..1).
-template <int NS, int KS>
-class MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared
-    : public MmtKernel {
-  static_assert(NS >= 4 && !(NS % 4));
-  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
-
-  virtual Type A_type() const override { return Type::FP16; }
-  virtual Type B_type() const override { return Type::FP16; }
-  virtual Type C_type() const override { return Type::FP32; }
-  virtual int M_tile() const override { return 8; }
-  virtual int N_tile() const override { return NS * 16; }
-  virtual int K_tile() const override { return KS * 32; }
-
-  virtual tile_layout_func_t A_tile_layout() const override {
-    return [](int m, int k) { return m * (KS * 32) + k; };
-  }
-
-  virtual tile_layout_func_t B_tile_layout() const override {
-    return [](int n, int k) {
-      int n_block = n / 16;
-      int n_col = n % 16;
-      return n_block * (KS * 512) + n_col * (KS * 32) + k;
-    };
-  }
-
-  virtual tile_layout_func_t C_tile_layout() const override {
-    return [](int m, int n) { return m * (NS * 16) + n; };
-  }
-
-  virtual int num_threads() const override { return 256; }
-  virtual mmt_func_t mmt_func() const override { return run; };
-
-  __global__ __launch_bounds__(256) static void run(
-      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
-      int /*M_outer*/, int N_outer, int K_outer) {
-    using f16x4 =
-        __attribute__((__vector_size__(4 * sizeof(_Float16)))) _Float16;
-    using f16x8 =
-        __attribute__((__vector_size__(8 * sizeof(_Float16)))) _Float16;
-    using f32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
-
-    f32x4 acc[NS / 4] = {{0}};
-
-    const int tid = threadIdx.x;
-    const int lane = tid % 64;
-    const int warp = tid / 64;
-
-    // A tile: 8 rows * KS*32 f16 elems = 8*KS*64 bytes, as f16x8 elements
-    // B tile: NS n-blocks * 16 n-cols * KS*32 f16 elems, as f16x8 elements
-    // Byte counts match the i8 variant (f16 is 2x wider but K_tile is halved).
-    constexpr int A_TILE_VEC16 = 8 * KS * 4;
-    constexpr int B_TILE_VEC16 = NS * KS * 64;
-
-    const auto *A_base = static_cast<const f16x8 *>(A_data) +
-                         blockIdx.x * K_outer * A_TILE_VEC16;
-    const auto *B_base = static_cast<const f16x8 *>(B_data) +
-                         blockIdx.y * K_outer * B_TILE_VEC16;
-    const auto *B_global_ptr = B_base + tid;
-
-    __shared__ f16x8 A_smem[A_TILE_VEC16];
-    __shared__ f16x8 B_smem[B_TILE_VEC16];
-    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
-
-    // Lane-to-data mapping for mfma_f32_16x16x16_f16
-    const int a_m_row = lane % 16;
-    const int a_k_group = lane / 16;
-    const int b_n_col = lane % 16;
-    const int b_k_group = lane / 16;
-
-    // Pre-compute A LDS base offset in bytes (only dereferenced when a_m_row < 8)
-    // Row stride: KS*32 f16 = KS*64 bytes. K-group stride: 4 f16 = 8 bytes.
-    const int a_lds_base = a_m_row * (KS * 64) + a_k_group * 8;
-
-    const f16x4 zero_a = {0, 0, 0, 0};
-
-    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      if (tid < A_TILE_VEC16) {
-        const f16x8 *A_ptr = A_base + k_outer * A_TILE_VEC16;
-        A_smem[tid] = A_ptr[tid];
-      }
-
-      for (int i = 0; i < B_TILE_VEC16; i += 256) {
-        B_smem[i + tid] = B_global_ptr[i];
-      }
-      B_global_ptr += B_TILE_VEC16;
-      __syncthreads();
-
-      for (int kb = 0; kb < KS; ++kb) {
-        for (int kh = 0; kh < 2; ++kh) {
-          // Load A: zero-pad for M-rows >= 8 (padding region)
-          // Each mfma call processes K=16: kb*32 + kh*16 .. kb*32 + kh*16 + 15
-          // Byte offset within tile: kb*64 + kh*32 (since 16 f16 = 32 bytes)
-          f16x4 a_reg = (a_m_row < 8)
-              ? *reinterpret_cast<f16x4 *>(
-                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
-              : zero_a;
-
-          for (int j = 0; j < NS / 4; ++j) {
-            int n_block = j * 4 + warp;
-
-            auto *b_ptr = reinterpret_cast<f16x4 *>(
-                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
-                b_n_col * (KS * 64) + kb * 64 + kh * 32 + b_k_group * 8);
-            f16x4 b_reg = *b_ptr;
-
-            acc[j] = __builtin_amdgcn_mfma_f32_16x16x16f16(
-                a_reg, b_reg, acc[j], 0, 0, 0);
-          }
-        }
-        __syncthreads();
-      }
-    }
-
-    // Output: d[p] = C[4*(lane/16) + p][lane%16]
-    // Only lane/16 < 2 (rows 0-7) contain real results.
-    constexpr int N_STRIDE = NS * 16;
-    constexpr int TILE_ELEMS = 8 * N_STRIDE;
-    const int g = lane / 16;
-    const int n_col_out = lane % 16;
-
-    float *C_tile = static_cast<float *>(C_data) +
-                    TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
-
-    if (g < 2) {
-      const int m_base = g * 4;
-      for (int j = 0; j < NS / 4; ++j) {
-        const int n = (j * 4 + warp) * 16 + n_col_out;
-        auto *d = reinterpret_cast<float *>(&acc[j]);
-        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
-        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
-        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
-        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
-      }
-    }
-  }
-};
-
 // The `smfmac` kernels are designed for skinny GEMMs (M=8)
 // by using sparse MFMA intrinsics to perform a fully dense
 // matmul. SMFMAC takes a 4:2-sparse operand A (where we
@@ -3986,6 +3689,276 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
       float *regD = reinterpret_cast<float *>(&acc[j]);
       C_tile[m0 * N_stride + n] = regD[0];
       C_tile[m1 * N_stride + n] = regD[1];
+    }
+  }
+};
+
+// M-padded MFMA kernel for skinny GEMMs (M=8->16).
+// Uses the dense mfma_i32_16x16x32_i8 instruction with zero-padding
+// on the A operand for lanes corresponding to M-rows 8-15.
+// This serves as a benchmark comparison against the smfmac sparse
+// trick kernel above, which achieves the same M=8 matmul using
+// smfmac_i32_16x16x64_i8.
+template <int NS, int KS>
+class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  virtual Type A_type() const override { return Type::SI8; }
+  virtual Type B_type() const override { return Type::SI8; }
+  virtual Type C_type() const override { return Type::SI32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 64; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 64) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 1024) + n_col * (KS * 64) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using int8x8_t = int64_t;
+    using int32x4_t = __attribute__((__vector_size__(16))) int32_t;
+    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
+
+    int32x4_t acc[NS / 4] = {{0}};
+
+    const int tid = threadIdx.x;
+    const int lane = tid % 64;
+    const int warp = tid / 64;
+
+    constexpr int A_TILE_VEC16 = 8 * KS * 4;
+    constexpr int B_TILE_VEC16 = NS * KS * 64;
+
+    const auto *A_base = static_cast<const i8x16 *>(A_data) +
+                         blockIdx.x * K_outer * A_TILE_VEC16;
+    const auto *B_base = static_cast<const i8x16 *>(B_data) +
+                         blockIdx.y * K_outer * B_TILE_VEC16;
+    const auto *B_global_ptr = B_base + tid;
+
+    __shared__ i8x16 A_smem[A_TILE_VEC16];
+    __shared__ i8x16 B_smem[B_TILE_VEC16];
+    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
+
+    const int a_m_row = lane % 16;
+    const int a_k_half = lane / 16;
+    const int b_cons_n_col = lane % 16;
+    const int b_cons_k_slice = lane / 16;
+
+    const int a_lds_base = a_m_row * (KS * 64) + a_k_half * 8;
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      if (tid < A_TILE_VEC16) {
+        const i8x16 *A_ptr = A_base + k_outer * A_TILE_VEC16;
+        A_smem[tid] = A_ptr[tid];
+      }
+
+      for (int i = 0; i < B_TILE_VEC16; i += 256) {
+        B_smem[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_TILE_VEC16;
+      __syncthreads();
+
+      for (int kb = 0; kb < KS; ++kb) {
+        for (int kh = 0; kh < 2; ++kh) {
+          // Load A: zero-pad for M-rows >= 8 (padding region)
+          int8x8_t a_reg = (a_m_row < 8)
+              ? *reinterpret_cast<int8x8_t *>(
+                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
+              : 0;
+
+          for (int j = 0; j < NS / 4; ++j) {
+            int n_block = j * 4 + warp;
+
+            auto *b_ptr = reinterpret_cast<int8x8_t *>(
+                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
+                b_cons_n_col * (KS * 64) + kb * 64 + kh * 32 +
+                b_cons_k_slice * 8);
+            int8x8_t b_reg = *b_ptr;
+
+            acc[j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
+                a_reg, b_reg, acc[j], 0, 0, 0);
+          }
+        }
+        __syncthreads();
+      }
+    }
+
+    // Output: d[p] = C[4*(lane/16) + p][lane%16]
+    // Only lane/16 < 2 (rows 0-7) contain real results.
+    constexpr int N_STRIDE = NS * 16;
+    constexpr int TILE_ELEMS = 8 * N_STRIDE;
+    const int m_group = lane / 16;
+    const int n_col_out = lane % 16;
+
+    int32_t *C_tile = static_cast<int32_t *>(C_data) +
+                      TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
+
+    if (m_group < 2) {
+      const int m_base = m_group * 4;
+      for (int j = 0; j < NS / 4; ++j) {
+        const int n = (j * 4 + warp) * 16 + n_col_out;
+        auto *d = reinterpret_cast<int32_t *>(&acc[j]);
+        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
+        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
+        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
+        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
+      }
+    }
+  }
+};
+
+// FP16 variant of the M-padded MFMA kernel for skinny GEMMs (M=8->16).
+// Uses the dense mfma_f32_16x16x16_f16 instruction with zero-padding
+// on the A operand for lanes corresponding to M-rows 8-15.
+//
+// For M=8: lanes with lane%16 >= 8 feed A=0 (zero-padding).
+// Output rows 0-7 are real (lane/16 < 2), rows 8-15 are discarded.
+// Since mfma processes K=16 vs smfmac's K=32, the inner loop runs
+// KS*2 iterations (nested kb=0..KS-1, kh=0..1).
+template <int NS, int KS>
+class MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  virtual Type A_type() const override { return Type::FP16; }
+  virtual Type B_type() const override { return Type::FP16; }
+  virtual Type C_type() const override { return Type::FP32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 32; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 32) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 512) + n_col * (KS * 32) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using f16x4 =
+        __attribute__((__vector_size__(4 * sizeof(_Float16)))) _Float16;
+    using f16x8 =
+        __attribute__((__vector_size__(8 * sizeof(_Float16)))) _Float16;
+    using f32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
+
+    f32x4 acc[NS / 4] = {{0}};
+
+    const int tid = threadIdx.x;
+    const int lane = tid % 64;
+    const int warp = tid / 64;
+
+    constexpr int A_TILE_VEC16 = 8 * KS * 4;
+    constexpr int B_TILE_VEC16 = NS * KS * 64;
+
+    const auto *A_base = static_cast<const f16x8 *>(A_data) +
+                         blockIdx.x * K_outer * A_TILE_VEC16;
+    const auto *B_base = static_cast<const f16x8 *>(B_data) +
+                         blockIdx.y * K_outer * B_TILE_VEC16;
+    const auto *B_global_ptr = B_base + tid;
+
+    __shared__ f16x8 A_smem[A_TILE_VEC16];
+    __shared__ f16x8 B_smem[B_TILE_VEC16];
+    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
+
+    const int a_m_row = lane % 16;
+    const int a_k_half = lane / 16;
+    const int b_cons_n_col = lane % 16;
+    const int b_cons_k_slice = lane / 16;
+
+    const int a_lds_base = a_m_row * (KS * 64) + a_k_half * 8;
+
+    const f16x4 zero_a = {0, 0, 0, 0};
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      if (tid < A_TILE_VEC16) {
+        const f16x8 *A_ptr = A_base + k_outer * A_TILE_VEC16;
+        A_smem[tid] = A_ptr[tid];
+      }
+
+      for (int i = 0; i < B_TILE_VEC16; i += 256) {
+        B_smem[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_TILE_VEC16;
+      __syncthreads();
+
+      for (int kb = 0; kb < KS; ++kb) {
+        for (int kh = 0; kh < 2; ++kh) {
+          // Load A: zero-pad for M-rows >= 8 (padding region)
+          f16x4 a_reg = (a_m_row < 8)
+              ? *reinterpret_cast<f16x4 *>(
+                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
+              : zero_a;
+
+          for (int j = 0; j < NS / 4; ++j) {
+            int n_block = j * 4 + warp;
+
+            auto *b_ptr = reinterpret_cast<f16x4 *>(
+                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
+                b_cons_n_col * (KS * 64) + kb * 64 + kh * 32 +
+                b_cons_k_slice * 8);
+            f16x4 b_reg = *b_ptr;
+
+            acc[j] = __builtin_amdgcn_mfma_f32_16x16x16f16(
+                a_reg, b_reg, acc[j], 0, 0, 0);
+          }
+        }
+        __syncthreads();
+      }
+    }
+
+    // Output: d[p] = C[4*(lane/16) + p][lane%16]
+    // Only lane/16 < 2 (rows 0-7) contain real results.
+    constexpr int N_STRIDE = NS * 16;
+    constexpr int TILE_ELEMS = 8 * N_STRIDE;
+    const int m_group = lane / 16;
+    const int n_col_out = lane % 16;
+
+    float *C_tile = static_cast<float *>(C_data) +
+                    TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
+
+    if (m_group < 2) {
+      const int m_base = m_group * 4;
+      for (int j = 0; j < NS / 4; ++j) {
+        const int n = (j * 4 + warp) * 16 + n_col_out;
+        auto *d = reinterpret_cast<float *>(&acc[j]);
+        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
+        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
+        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
+        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
+      }
     }
   }
 };

--- a/matmul.hip
+++ b/matmul.hip
@@ -3314,15 +3314,8 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
     int n_outer = blockIdx.y;
     int tid = threadIdx.x;
 
-    // M tile = MS * 16 = 128 
-    // Total bytes in A tile (128 x 32)
-    // M_tile x K_tile x sizeof(int8) = 128 * 32 * 1 = 4096 bytes
-    // Each int8x8_t = 8 bytes
-    // So A tile size in int8x8_t = 4096 / 8 = 512
-    // this should really be MS * 
-    // 1 * 16
-    constexpr int A_tile_size_in_vec8 = MS * 16 * 4; // 8 * 16 * 4 = 512
-    constexpr int B_tile_size_in_vec8 = NS * 16 * 4; // 8 * 16 * 4 = 512
+    constexpr int A_tile_size_in_vec8 = MS * 16 * 4;
+    constexpr int B_tile_size_in_vec8 = NS * 16 * 4;
 
     const int8x8_t *A_global = static_cast<const int8x8_t *>(A_data) +
                                m_outer * K_outer * A_tile_size_in_vec8;
@@ -3331,13 +3324,12 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
     const int8x8_t *A_global_ptr = A_global + tid;
     const int8x8_t *B_global_ptr = B_global + tid;
 
-    // so we have enough shared memory for 8 MFMAs
-    __shared__ int8x8_t A_shared[A_tile_size_in_vec8]; //512 * (64/8) = 4096 bytes / 8 = 512 per MFMA call which is 16 * 32 = correct
+    __shared__ int8x8_t A_shared[A_tile_size_in_vec8];
     __shared__ int8x8_t B_shared[B_tile_size_in_vec8];
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
       for (int i = 0; i < A_tile_size_in_vec8; i += 256) { 
-        A_shared[i + tid] = A_global_ptr[i]; // 64bits load // 256 * 8 = 2048 bytes total, 2 iterations = 4096
+        A_shared[i + tid] = A_global_ptr[i];
       }
       for (int j = 0; j < B_tile_size_in_vec8; j += 256) {
         B_shared[j + tid] = B_global_ptr[j];
@@ -3346,42 +3338,8 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
       B_global_ptr += B_tile_size_in_vec8;
       __syncthreads();
 
-      // in total would run 16 times/16 MFMAs per tile
       for (int i = 0; i < MS; ++i) { 
         for (int j = 0; j < NS / 4; ++j) { 
-            // i = 0 -> 8 gives us 512
-            // j = 0 -> 2 gives us 512
-            /*
-            i = 0
-              tid = 0 -> 64 * 0 + (0 % 64) = 0
-              tid = 1 -> 64 * 0 + (1 % 64) = 1
-              tid = 254 -> 64 * 0 + (254 % 64) = 62
-              tid = 255 -> 64 * 0 + (255 % 64) = 63
-            i = 1
-              tid = 0 -> 64 * 1 + (0 % 64) = 64
-              tid = 1 -> 64 * 1 + (1 % 64) = 65
-              tid = 254 -> 64 * 1 + (254 % 64) = 126
-              tid = 255 -> 64 * 1 + (255 % 64) = 127
-            i = 2
-              tid = 0 -> 64 * 2 + (0 % 64) = 128
-              tid = 1 -> 64 * 2 + (1 % 64) = 129
-              tid = 254 -> 64 * 2 + (254 % 64) = 190
-              tid = 255 -> 64 * 2 + (255 % 64) = 191
-            j = 0
-              tid = 0 -> 256 * 0 + 0 = 0
-              tid = 1 -> 256 * 0 + 1 = 1
-              tid = 254 -> 256 * 0 + 254 = 254
-              tid = 255 -> 256 * 0 + 255 = 255
-            j = 1
-              tid = 0 -> 256 * 1 + 0 = 256
-              tid = 1 -> 256 * 1 + 1 = 257
-              tid = 254 -> 256 * 1 + 254 = 510
-              tid = 255 -> 256 * 1 + 255 = 511
-            */
-            /*
-            j hits 4 MFMAs ( 256 / 64 = 4 subgroups) 
-            // i broadcasts value to j each time
-            */
           acc[i][j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
               A_shared[64 * i + (tid % 64)], B_shared[256 * j + tid], acc[i][j],
               0, 0, 0);

--- a/matmul.hip
+++ b/matmul.hip
@@ -3403,6 +3403,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     using i8x8 = __attribute__((__vector_size__(8))) int8_t;
     using i8x16 = __attribute__((__vector_size__(16))) int8_t;
     using i32x4 = __attribute__((__vector_size__(16))) int32_t;
+    using i16x4 = __attribute__((__vector_size__(8))) int16_t;
 
     union {
       i8x8 vec;
@@ -3426,19 +3427,15 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
                          blockIdx.y * K_outer * B_TILE_VEC16;
     const auto *B_global_ptr = B_base + tid;
 
-    __shared__ int8_t A_smem_raw[KS * 512];
+    __shared__ i8x16 A_smem[A_TILE_VEC16];
     __shared__ i8x16 B_smem[B_TILE_VEC16];
-    auto *A_smem = reinterpret_cast<int32_t *>(A_smem_raw);
-
-    const int a_prod_row = tid / (KS * 4);
-    const int a_prod_chunk = tid % (KS * 4);
-    const int a_prod_bank = a_prod_chunk / 4;
-    const int a_prod_col = a_prod_row + (a_prod_chunk % 4) * 8;
+    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
 
     const int a_cons_m_pair = (lane % 16) / 2;
     const int a_cons_is_odd = lane % 2;
     const int a_cons_k_half = lane / 16;
-    const int a_cons_col = a_cons_m_pair + a_cons_k_half * 8;
+    const int a_cons_lds_base =
+        a_cons_m_pair * (KS * 64) + a_cons_k_half * 16 + a_cons_is_odd * 8;
 
     const int b_cons_n_col = lane % 16;
     const int b_cons_k_slice = lane / 16;
@@ -3446,32 +3443,8 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     const int sparsity_idx = (lane & 1) ? SPARSITY_ODD : SPARSITY_EVEN;
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      // Load & swizzle A tile into LDS:
-      // Swizzle separates K positions that will be owned by even/odd threads
-      // into distinct LDS lines.
-      // Input vec16:
-      // [K0,K1,K2,K3] [K4,K5,K6,K7] [K8,K9,K10,K11] [K12,K13,K14,K15]
-      // Line 0: K0,K1,K4,K5  Line 1: K8,K9,K12,K13 (even threads)
-      // Line 2: K2,K3,K6,K7  Line 3: K10,K11,K14,K15 (odd threads)
       if (tid < A_TILE_VEC16) {
-        const auto *A_tile = A_base + k_outer * A_TILE_VEC16;
-        i8x16 loaded = A_tile[a_prod_row * (KS * 4) + a_prod_chunk];
-
-        auto *src = reinterpret_cast<int32_t *>(&loaded);
-        int32_t lo0, lo1, hi0, hi1;
-        asm volatile("v_pack_b32_f16 %0, %4, %5 op_sel:[0,0]\n\t"
-                     "v_pack_b32_f16 %1, %6, %7 op_sel:[0,0]\n\t"
-                     "v_pack_b32_f16 %2, %4, %5 op_sel:[1,1]\n\t"
-                     "v_pack_b32_f16 %3, %6, %7 op_sel:[1,1]\n\t"
-                     : "=&v"(lo0), "=&v"(lo1), "=&v"(hi0), "=&v"(hi1)
-                     : "v"(src[0]), "v"(src[1]), "v"(src[2]), "v"(src[3]));
-
-        // Store into bank-interleaved LDS: 4 lines × 32 columns per bank
-        int32_t *bank = A_smem + a_prod_bank * 128;
-        bank[0 * NB_BANKS + a_prod_col] = lo0; // even tid, low
-        bank[1 * NB_BANKS + a_prod_col] = lo1; // even tid, high
-        bank[2 * NB_BANKS + a_prod_col] = hi0; // odd tid, low
-        bank[3 * NB_BANKS + a_prod_col] = hi1; // odd tid, high
+        A_smem[tid] = (A_base + k_outer * A_TILE_VEC16)[tid];
       }
 
       for (int i = 0; i < B_TILE_VEC16; i += 256) {
@@ -3482,12 +3455,23 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // Load A from LDS: 8 bytes spanning two lines (0, 1 for even or 2, 3
-        // for odd)
-        auto *a_ptr = reinterpret_cast<int32_t *>(
-            A_smem_raw + kb * 512 + a_cons_col * 4 + a_cons_is_odd * 256);
-        a_reg.i32[0] = a_ptr[0];
-        a_reg.i32[1] = a_ptr[NB_BANKS];
+        // TODO: explain change.
+        auto *a_ptr =
+            reinterpret_cast<int2 *>(A_smem_bytes + a_cons_lds_base + kb * 64);
+        auto a_i16 = __builtin_bit_cast(i16x4, *a_ptr);
+        int pack_lo = __builtin_bit_cast(
+            int, __builtin_shufflevector(a_i16, a_i16, 0, 2));
+        int pack_hi = __builtin_bit_cast(
+            int, __builtin_shufflevector(a_i16, a_i16, 1, 3));
+
+        constexpr int kQuadPermSwap = 0xB1;
+        int neighbor_lo =
+            __builtin_amdgcn_mov_dpp(pack_lo, kQuadPermSwap, 0xF, 0xF, false);
+        int neighbor_hi =
+            __builtin_amdgcn_mov_dpp(pack_hi, kQuadPermSwap, 0xF, 0xF, false);
+
+        a_reg.i32[0] = (a_cons_is_odd == 0) ? pack_lo : neighbor_hi;
+        a_reg.i32[1] = (a_cons_is_odd == 0) ? neighbor_lo : pack_hi;
 
         for (int j = 0; j < NS / 4; ++j) {
           int n_block = j * 4 + warp;

--- a/matmul.hip
+++ b/matmul.hip
@@ -3437,7 +3437,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     const int lane = tid % 64;
     const int warp = tid / 64;
 
-    // A tile: 8 rows × KS banks × 4 lines/bank × 32 cols × 4B = KS*512 bytes
+    // A tile: 8 rows × KS banks × 4 groups of K = KS*512 bytes
     // B tile: NS n-blocks × KS k-banks × 64 vec16 elements
     constexpr int A_TILE_VEC16 = 8 * KS * 4;
     constexpr int B_TILE_VEC16 = NS * KS * 64;

--- a/matmul.hip
+++ b/matmul.hip
@@ -3503,6 +3503,158 @@ class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
   }
 };
 
+// FP16 variant of the M-padded MFMA kernel for skinny GEMMs (M=8->16).
+// Uses the dense mfma_f32_16x16x16_f16 instruction with zero-padding
+// on the A operand for lanes corresponding to M-rows 8-15.
+// Companion to the i8 zeropad kernel above; benchmarks the overhead of
+// M-padding with dense mfma vs the sparse trick with smfmac for FP16.
+//
+// Lane mapping for mfma_f32_16x16x16_f16:
+//   A operand: lane%16 = M-row (0-15), lane/16 = K-group (0-3), 4 f16 per lane
+//   B operand: lane%16 = N-col (0-15), lane/16 = K-group (0-3), 4 f16 per lane
+//   Output: d[p] = C[4*(lane/16) + p][lane%16], p=0..3
+//
+// For M=8: lanes with lane%16 >= 8 feed A=0 (zero-padding).
+// Output rows 0-7 are real (lane/16 < 2), rows 8-15 are discarded.
+// Since mfma processes K=16 vs smfmac's K=32, the inner loop runs
+// KS*2 iterations (nested kb=0..KS-1, kh=0..1).
+template <int NS, int KS>
+class MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  virtual Type A_type() const override { return Type::FP16; }
+  virtual Type B_type() const override { return Type::FP16; }
+  virtual Type C_type() const override { return Type::FP32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 32; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 32) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 512) + n_col * (KS * 32) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using f16x4 =
+        __attribute__((__vector_size__(4 * sizeof(_Float16)))) _Float16;
+    using f16x8 =
+        __attribute__((__vector_size__(8 * sizeof(_Float16)))) _Float16;
+    using f32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
+
+    f32x4 acc[NS / 4] = {{0}};
+
+    const int tid = threadIdx.x;
+    const int lane = tid % 64;
+    const int warp = tid / 64;
+
+    // A tile: 8 rows * KS*32 f16 elems = 8*KS*64 bytes, as f16x8 elements
+    // B tile: NS n-blocks * 16 n-cols * KS*32 f16 elems, as f16x8 elements
+    // Byte counts match the i8 variant (f16 is 2x wider but K_tile is halved).
+    constexpr int A_TILE_VEC16 = 8 * KS * 4;
+    constexpr int B_TILE_VEC16 = NS * KS * 64;
+
+    const auto *A_base = static_cast<const f16x8 *>(A_data) +
+                         blockIdx.x * K_outer * A_TILE_VEC16;
+    const auto *B_base = static_cast<const f16x8 *>(B_data) +
+                         blockIdx.y * K_outer * B_TILE_VEC16;
+    const auto *B_global_ptr = B_base + tid;
+
+    __shared__ f16x8 A_smem[A_TILE_VEC16];
+    __shared__ f16x8 B_smem[B_TILE_VEC16];
+    auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
+
+    // Lane-to-data mapping for mfma_f32_16x16x16_f16
+    const int a_m_row = lane % 16;
+    const int a_k_group = lane / 16;
+    const int b_n_col = lane % 16;
+    const int b_k_group = lane / 16;
+
+    // Pre-compute A LDS base offset in bytes (only dereferenced when a_m_row < 8)
+    // Row stride: KS*32 f16 = KS*64 bytes. K-group stride: 4 f16 = 8 bytes.
+    const int a_lds_base = a_m_row * (KS * 64) + a_k_group * 8;
+
+    const f16x4 zero_a = {0, 0, 0, 0};
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      if (tid < A_TILE_VEC16) {
+        const f16x8 *A_ptr = A_base + k_outer * A_TILE_VEC16;
+        A_smem[tid] = A_ptr[tid];
+      }
+
+      for (int i = 0; i < B_TILE_VEC16; i += 256) {
+        B_smem[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_TILE_VEC16;
+      __syncthreads();
+
+      for (int kb = 0; kb < KS; ++kb) {
+        for (int kh = 0; kh < 2; ++kh) {
+          // Load A: zero-pad for M-rows >= 8 (padding region)
+          // Each mfma call processes K=16: kb*32 + kh*16 .. kb*32 + kh*16 + 15
+          // Byte offset within tile: kb*64 + kh*32 (since 16 f16 = 32 bytes)
+          f16x4 a_reg = (a_m_row < 8)
+              ? *reinterpret_cast<f16x4 *>(
+                    A_smem_bytes + a_lds_base + kb * 64 + kh * 32)
+              : zero_a;
+
+          for (int j = 0; j < NS / 4; ++j) {
+            int n_block = j * 4 + warp;
+
+            auto *b_ptr = reinterpret_cast<f16x4 *>(
+                reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
+                b_n_col * (KS * 64) + kb * 64 + kh * 32 + b_k_group * 8);
+            f16x4 b_reg = *b_ptr;
+
+            acc[j] = __builtin_amdgcn_mfma_f32_16x16x16f16(
+                a_reg, b_reg, acc[j], 0, 0, 0);
+          }
+        }
+        __syncthreads();
+      }
+    }
+
+    // Output: d[p] = C[4*(lane/16) + p][lane%16]
+    // Only lane/16 < 2 (rows 0-7) contain real results.
+    constexpr int N_STRIDE = NS * 16;
+    constexpr int TILE_ELEMS = 8 * N_STRIDE;
+    const int g = lane / 16;
+    const int n_col_out = lane % 16;
+
+    float *C_tile = static_cast<float *>(C_data) +
+                    TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
+
+    if (g < 2) {
+      const int m_base = g * 4;
+      for (int j = 0; j < NS / 4; ++j) {
+        const int n = (j * 4 + warp) * 16 + n_col_out;
+        auto *d = reinterpret_cast<float *>(&acc[j]);
+        C_tile[(m_base + 0) * N_STRIDE + n] = d[0];
+        C_tile[(m_base + 1) * N_STRIDE + n] = d[1];
+        C_tile[(m_base + 2) * N_STRIDE + n] = d[2];
+        C_tile[(m_base + 3) * N_STRIDE + n] = d[3];
+      }
+    }
+  }
+};
+
 // The `smfmac` kernels are designed for skinny GEMMs (M=8)
 // by using sparse MFMA intrinsics to perform a fully dense
 // matmul. SMFMAC takes a 4:2-sparse operand A (where we
@@ -4281,6 +4433,12 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 2>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 4>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 8>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 2>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 4>());
+  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<16, 2>());
 
   std::printf("\n\n\nStream-K experiments:\n\n");
   test(

--- a/matmul.hip
+++ b/matmul.hip
@@ -3314,8 +3314,15 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
     int n_outer = blockIdx.y;
     int tid = threadIdx.x;
 
-    constexpr int A_tile_size_in_vec8 = MS * 16 * 4;
-    constexpr int B_tile_size_in_vec8 = NS * 16 * 4;
+    // M tile = MS * 16 = 128 
+    // Total bytes in A tile (128 x 32)
+    // M_tile x K_tile x sizeof(int8) = 128 * 32 * 1 = 4096 bytes
+    // Each int8x8_t = 8 bytes
+    // So A tile size in int8x8_t = 4096 / 8 = 512
+    // this should really be MS * 
+    // 1 * 16
+    constexpr int A_tile_size_in_vec8 = MS * 16 * 4; // 8 * 16 * 4 = 512
+    constexpr int B_tile_size_in_vec8 = NS * 16 * 4; // 8 * 16 * 4 = 512
 
     const int8x8_t *A_global = static_cast<const int8x8_t *>(A_data) +
                                m_outer * K_outer * A_tile_size_in_vec8;
@@ -3324,12 +3331,13 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
     const int8x8_t *A_global_ptr = A_global + tid;
     const int8x8_t *B_global_ptr = B_global + tid;
 
-    __shared__ int8x8_t A_shared[A_tile_size_in_vec8];
+    // so we have enough shared memory for 8 MFMAs
+    __shared__ int8x8_t A_shared[A_tile_size_in_vec8]; //512 * (64/8) = 4096 bytes / 8 = 512 per MFMA call which is 16 * 32 = correct
     __shared__ int8x8_t B_shared[B_tile_size_in_vec8];
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      for (int i = 0; i < A_tile_size_in_vec8; i += 256) {
-        A_shared[i + tid] = A_global_ptr[i];
+      for (int i = 0; i < A_tile_size_in_vec8; i += 256) { 
+        A_shared[i + tid] = A_global_ptr[i]; // 64bits load // 256 * 8 = 2048 bytes total, 2 iterations = 4096
       }
       for (int j = 0; j < B_tile_size_in_vec8; j += 256) {
         B_shared[j + tid] = B_global_ptr[j];
@@ -3338,8 +3346,42 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
       B_global_ptr += B_tile_size_in_vec8;
       __syncthreads();
 
-      for (int i = 0; i < MS; ++i) {
-        for (int j = 0; j < NS / 4; ++j) {
+      // in total would run 16 times/16 MFMAs per tile
+      for (int i = 0; i < MS; ++i) { 
+        for (int j = 0; j < NS / 4; ++j) { 
+            // i = 0 -> 8 gives us 512
+            // j = 0 -> 2 gives us 512
+            /*
+            i = 0
+              tid = 0 -> 64 * 0 + (0 % 64) = 0
+              tid = 1 -> 64 * 0 + (1 % 64) = 1
+              tid = 254 -> 64 * 0 + (254 % 64) = 62
+              tid = 255 -> 64 * 0 + (255 % 64) = 63
+            i = 1
+              tid = 0 -> 64 * 1 + (0 % 64) = 64
+              tid = 1 -> 64 * 1 + (1 % 64) = 65
+              tid = 254 -> 64 * 1 + (254 % 64) = 126
+              tid = 255 -> 64 * 1 + (255 % 64) = 127
+            i = 2
+              tid = 0 -> 64 * 2 + (0 % 64) = 128
+              tid = 1 -> 64 * 2 + (1 % 64) = 129
+              tid = 254 -> 64 * 2 + (254 % 64) = 190
+              tid = 255 -> 64 * 2 + (255 % 64) = 191
+            j = 0
+              tid = 0 -> 256 * 0 + 0 = 0
+              tid = 1 -> 256 * 0 + 1 = 1
+              tid = 254 -> 256 * 0 + 254 = 254
+              tid = 255 -> 256 * 0 + 255 = 255
+            j = 1
+              tid = 0 -> 256 * 1 + 0 = 256
+              tid = 1 -> 256 * 1 + 1 = 257
+              tid = 254 -> 256 * 1 + 254 = 510
+              tid = 255 -> 256 * 1 + 255 = 511
+            */
+            /*
+            j hits 4 MFMAs ( 256 / 64 = 4 subgroups) 
+            // i broadcasts value to j each time
+            */
           acc[i][j] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
               A_shared[64 * i + (tid % 64)], B_shared[256 * j + tid], acc[i][j],
               0, 0, 0);
@@ -3354,6 +3396,182 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
       for (int j = 0; j < NS / 4; ++j) {
         C_ptr[256 * (NS / 4 * i + j) + tid] = acc[i][j];
       }
+    }
+  }
+};
+
+template <int NS, int KS>
+class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
+    : public MmtKernel {
+  static_assert(NS >= 4 && !(NS % 4));
+  static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
+
+  // Sparsity indices for the sparse trick
+  static constexpr int SPARSITY_EVEN =
+      0x00004444; // Selects positions 0,1 from each group of 4 8-bit elements
+  static constexpr int SPARSITY_ODD =
+      0x0000EEEE; // Selects positions 2,3 from each group of 4 8-bit elements
+  static constexpr int NB_BANKS = 32;
+
+  virtual Type A_type() const override { return Type::SI8; }
+  virtual Type B_type() const override { return Type::SI8; }
+  virtual Type C_type() const override { return Type::SI32; }
+  virtual int M_tile() const override { return 8; }
+  virtual int N_tile() const override { return NS * 16; }
+  virtual int K_tile() const override { return KS * 64; }
+
+  virtual tile_layout_func_t A_tile_layout() const override {
+    return [](int m, int k) { return m * (KS * 64) + k; };
+  }
+
+  virtual tile_layout_func_t B_tile_layout() const override {
+    return [](int n, int k) {
+      int n_block = n / 16;
+      int n_col = n % 16;
+      return n_block * (KS * 1024) + n_col * (KS * 64) + k;
+    };
+  }
+
+  virtual tile_layout_func_t C_tile_layout() const override {
+    return [](int m, int n) { return m * (NS * 16) + n; };
+  }
+
+  virtual int num_threads() const override { return 256; }
+  virtual mmt_func_t mmt_func() const override { return run; };
+
+  __global__ __launch_bounds__(256) static void run(
+      const void *A_data, const void *B_data, void *C_data, void * /*aux_data*/,
+      int /*M_outer*/, int N_outer, int K_outer) {
+    using i8x8 = __attribute__((__vector_size__(8))) int8_t;
+    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
+    using i32x4 = __attribute__((__vector_size__(16))) int32_t;
+
+    union {
+      i8x8 vec;
+      int32_t i32[2];
+    } a_reg;
+
+    i32x4 acc[NS / 4] = {{0}};
+
+    const int tid = threadIdx.x;
+    const int lane = tid % 64;
+    const int warp = tid / 64;
+
+    // A tile: 8 rows × KS banks × 4 lines/bank × 32 cols × 4B = KS*512 bytes
+    // B tile: NS n-blocks × KS k-banks × 64 vec16 elements
+    constexpr int A_TILE_VEC16 = 8 * KS * 4;
+    constexpr int B_TILE_VEC16 = NS * KS * 64;
+
+    const auto *A_base = static_cast<const i8x16 *>(A_data) +
+                         blockIdx.x * K_outer * A_TILE_VEC16;
+    const auto *B_base = static_cast<const i8x16 *>(B_data) +
+                         blockIdx.y * K_outer * B_TILE_VEC16;
+    const auto *B_global_ptr = B_base + tid;
+
+    __shared__ int8_t A_smem_raw[KS * 512];
+    __shared__ i8x16 B_smem[B_TILE_VEC16];
+    auto *A_smem = reinterpret_cast<int32_t *>(A_smem_raw);
+
+    const int a_prod_row = tid / (KS * 4);
+    const int a_prod_chunk = tid % (KS * 4);
+    const int a_prod_bank = a_prod_chunk / 4;
+    const int a_prod_col = a_prod_row + (a_prod_chunk % 4) * 8;
+
+    const int a_cons_m_pair = (lane % 16) / 2;
+    const int a_cons_is_odd = lane % 2;
+    const int a_cons_k_half = lane / 16;
+    const int a_cons_col = a_cons_m_pair + a_cons_k_half * 8;
+
+    const int b_cons_n_col = lane % 16;
+    const int b_cons_k_slice = lane / 16;
+
+    const int sparsity_idx = (lane & 1) ? SPARSITY_ODD : SPARSITY_EVEN;
+
+    for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
+      // Load & swizzle A tile into LDS:
+      // Swizzle separates K positions that will be owned by even/odd threads
+      // into distinct LDS lines.
+      // Input vec16:
+      // [K0,K1,K2,K3] [K4,K5,K6,K7] [K8,K9,K10,K11] [K12,K13,K14,K15]
+      // Line 0: K0,K1,K4,K5  Line 1: K8,K9,K12,K13 (even threads)
+      // Line 2: K2,K3,K6,K7  Line 3: K10,K11,K14,K15 (odd threads)
+      if (tid < A_TILE_VEC16) {
+        const auto *A_tile = A_base + k_outer * A_TILE_VEC16;
+        i8x16 loaded = A_tile[a_prod_row * (KS * 4) + a_prod_chunk];
+
+        auto *src = reinterpret_cast<int32_t *>(&loaded);
+        int32_t lo0, lo1, hi0, hi1;
+        asm volatile("v_pack_b32_f16 %0, %4, %5 op_sel:[0,0]\n\t"
+                     "v_pack_b32_f16 %1, %6, %7 op_sel:[0,0]\n\t"
+                     "v_pack_b32_f16 %2, %4, %5 op_sel:[1,1]\n\t"
+                     "v_pack_b32_f16 %3, %6, %7 op_sel:[1,1]\n\t"
+                     : "=&v"(lo0), "=&v"(lo1), "=&v"(hi0), "=&v"(hi1)
+                     : "v"(src[0]), "v"(src[1]), "v"(src[2]), "v"(src[3]));
+
+        // Store into bank-interleaved LDS: 4 lines × 32 columns per bank
+        int32_t *bank = A_smem + a_prod_bank * 128;
+        bank[0 * NB_BANKS + a_prod_col] = lo0; // even tid, low
+        bank[1 * NB_BANKS + a_prod_col] = lo1; // even tid, high
+        bank[2 * NB_BANKS + a_prod_col] = hi0; // odd tid, low
+        bank[3 * NB_BANKS + a_prod_col] = hi1; // odd tid, high
+      }
+
+      for (int i = 0; i < B_TILE_VEC16; i += 256) {
+        B_smem[i + tid] = B_global_ptr[i];
+      }
+      B_global_ptr += B_TILE_VEC16;
+
+      __syncthreads();
+
+      for (int kb = 0; kb < KS; ++kb) {
+        // Load A from LDS: 8 bytes spanning two lines (even or odd K half)
+        auto *a_ptr = reinterpret_cast<int32_t *>(
+            A_smem_raw + kb * 512 + a_cons_col * 4 + a_cons_is_odd * 256);
+        a_reg.i32[0] = a_ptr[0];
+        a_reg.i32[1] = a_ptr[NB_BANKS];
+
+        for (int j = 0; j < NS / 4; ++j) {
+          int n_block = j * 4 + warp;
+
+          // Load B from LDS: 16 bytes for this lane's (n_col, k_slice)
+          auto *b_ptr = reinterpret_cast<i8x16 *>(
+              reinterpret_cast<int8_t *>(B_smem) + n_block * (KS * 1024) +
+              b_cons_n_col * (KS * 64) + kb * 64 + b_cons_k_slice * 16);
+          i8x16 b_reg = *b_ptr;
+
+          acc[j] = __builtin_amdgcn_smfmac_i32_16x16x64_i8(
+              a_reg.vec, b_reg, acc[j], sparsity_idx, 0, 0);
+        }
+      }
+    }
+
+    // Post-processing: fuse even + odd K partial sums
+    // SMFMAC with the sparsity trick produces interleaved even/odd results:
+    //   acc[j][0] = row0 × B (even K),  acc[j][1] = row0 × B (odd K)
+    //   acc[j][2] = row1 × B (even K),  acc[j][3] = row1 × B (odd K)
+    // Fusing gives the complete dot product per row.
+    for (int j = 0; j < NS / 4; ++j) {
+      auto *d = reinterpret_cast<int32_t *>(&acc[j]);
+      d[0] = d[0] + d[1]; // row0 complete
+      d[1] = d[2] + d[3]; // row1 complete
+    }
+
+    constexpr int N_STRIDE = NS * 16;
+    constexpr int TILE_ELEMS = 8 * N_STRIDE;
+
+    const int m_pair = lane / 16;
+    const int m0 = m_pair * 2;
+    const int m1 = m0 + 1;
+    const int n_col_out = lane % 16;
+
+    int32_t *C_tile = static_cast<int32_t *>(C_data) +
+                      TILE_ELEMS * (N_outer * blockIdx.x + blockIdx.y);
+
+    for (int j = 0; j < NS / 4; ++j) {
+      const int n = (j * 4 + warp) * 16 + n_col_out;
+      auto *d = reinterpret_cast<int32_t *>(&acc[j]);
+      C_tile[m0 * N_STRIDE + n] = d[0];
+      C_tile[m1 * N_STRIDE + n] = d[1];
     }
   }
 };
@@ -3781,6 +3999,14 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2<8, 8>());
   test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
        8, 8>());
+
+  std::printf("\n\n\nSMFMAC sparse trick experiments:\n\n");
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<16, 2>());
 
   std::printf("\n\n\nStream-K experiments:\n\n");
   test(

--- a/matmul.hip
+++ b/matmul.hip
@@ -3474,26 +3474,22 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // The sparse MFMA intrinsic takes non-zero
-        // elements plus sparsity indices that specify which
-        // 2 of 4 positions are non-zero. For a dense row:
-        //
-        //   K0 K1 K2 K3 K4 K5 ... K12 K13 K14 K15
-        //
-        // We can represent it across an even/odd lane pair as a sparse row by
-        // allowing even tids to hold positions {0,1} and odd tids to hold
-        // {2,3} within each group of 4:
+        // We can represent a dense row across an even/odd lane pair as a sparse
+        // row by allowing even tids to hold positions {0,1} and odd tids to
+        // hold {2,3} within each group of 4:
         //
         //   even: K0 K1 _  _  K4 K5 _  _  ...
         //   odd:  _  _  K2 K3 _  _  K6 K7 ...
         //
-        // From LDS, each lane loads 8 contiguous elements
+        // From LDS, each pair of lanes loads the following:
         //   even: K0 K1 K2 K3 | K4 K5 K6 K7
         //   odd:  K8 K9 K10 K11 | K12 K13 K14 K15
-        // But this must be transformed to align with the sparsity index:
+        // But this must be transformed to align with the sparsity index that
+        // represents:
         //   even: K0 K1 K4 K5 | K8 K9 K12 K13
         //   odd:  K2 K3 K6 K7 | K10 K11 K14 K15
 
+        // Load A from LDS: 8 bytes for this lane's groups
         auto *a_ptr =
             reinterpret_cast<int2 *>(A_smem_bytes + a_lds_base + kb * 64);
         auto a_i16 = __builtin_bit_cast(i16x4, *a_ptr);

--- a/matmul.hip
+++ b/matmul.hip
@@ -3485,6 +3485,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
           acc[j] = __builtin_amdgcn_smfmac_i32_16x16x64_i8(
               a_reg.vec, b_reg, acc[j], sparsity_idx, 0, 0);
         }
+        __syncthreads();
       }
     }
 
@@ -3583,21 +3584,14 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
                             n_outer * K_outer * B_tile_size_in_vec16;
     const f16x8 *B_global_ptr = B_global + tid;
 
-    __shared__ int8_t A_shared[KS * 512];
+    __shared__ f16x8 A_shared[A_tile_size_in_vec16];
     __shared__ f16x8 B_shared[B_tile_size_in_vec16];
-
-    int a_row_prod = tid / (KS * 4);
-    int a_k_chunk = tid % (KS * 4);
-    int a_bank = a_k_chunk / 4;
-    int k_chunk_in_bank = a_k_chunk % 4;
-    int a_col_prod = a_row_prod + k_chunk_in_bank * 8;
-
-    int32_t *A_lds = reinterpret_cast<int32_t *>(A_shared);
+    auto *A_shared_bytes = reinterpret_cast<int8_t *>(A_shared);
 
     int a_m_row = (lane_id % 16) / 2;
     int a_is_odd = lane_id % 2;
     int a_k_range = lane_id / 16;
-    int a_col_cons = a_m_row + a_k_range * 8;
+    int a_lds_base = a_m_row * (KS * 64) + a_k_range * 16;
 
     int n_col = lane_id % 16;
     int k_slice = lane_id / 16;
@@ -3606,19 +3600,8 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
       const f16x8 *A_tile_base = A_global + k_outer * A_tile_size_in_vec16;
-
       if (tid < A_tile_size_in_vec16) {
-        f16x8 a_loaded = A_tile_base[a_row_prod * (KS * 4) + a_k_chunk];
-        int32_t reg0 = reinterpret_cast<int32_t *>(&a_loaded)[0]; // [K0, K1]
-        int32_t reg1 = reinterpret_cast<int32_t *>(&a_loaded)[1]; // [K2, K3]
-        int32_t reg2 = reinterpret_cast<int32_t *>(&a_loaded)[2]; // [K4, K5]
-        int32_t reg3 = reinterpret_cast<int32_t *>(&a_loaded)[3]; // [K6, K7]
-
-        int32_t *bank_base = A_lds + a_bank * 128;
-        bank_base[0 * NB_BANKS + a_col_prod] = reg0; // Line 0: EVEN [K0, K1]
-        bank_base[1 * NB_BANKS + a_col_prod] = reg2; // Line 1: EVEN [K4, K5]
-        bank_base[2 * NB_BANKS + a_col_prod] = reg1; // Line 2: ODD  [K2, K3]
-        bank_base[3 * NB_BANKS + a_col_prod] = reg3; // Line 3: ODD  [K6, K7]
+        A_shared[tid] = A_tile_base[tid];
       }
 
       for (int i = 0; i < B_tile_size_in_vec16; i += 256) {
@@ -3628,11 +3611,11 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
       __syncthreads();
 
       for (int k_bank = 0; k_bank < KS; ++k_bank) {
-        int8_t *a_cons =
-            A_shared + k_bank * 512 + a_col_cons * 4 + a_is_odd * 256;
-        int32_t *a_ptr = reinterpret_cast<int32_t *>(a_cons);
-        a_reg.i32[0] = a_ptr[0];
-        a_reg.i32[1] = a_ptr[NB_BANKS];
+        auto *a_ptr = reinterpret_cast<f16x8 *>(A_shared_bytes + a_lds_base +
+                                                k_bank * 64);
+        auto *a_i32 = reinterpret_cast<int32_t *>(a_ptr);
+        a_reg.i32[0] = a_is_odd ? a_i32[1] : a_i32[0];
+        a_reg.i32[1] = a_is_odd ? a_i32[3] : a_i32[2];
 
         for (int j = 0; j < NS / 4; ++j) {
           int n_block = j * 4 + warp_id;
@@ -3645,6 +3628,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
           acc[j] = __builtin_amdgcn_smfmac_f32_16x16x32_f16(
               a_reg.vec, b_reg, acc[j], sparsity_idx, 0, 0);
         }
+        __syncthreads();
       }
     }
 

--- a/matmul.hip
+++ b/matmul.hip
@@ -3444,7 +3444,8 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
       if (tid < A_TILE_VEC16) {
-        A_smem[tid] = (A_base + k_outer * A_TILE_VEC16)[tid];
+        const i8x16 *A_ptr = A_base + k_outer * A_TILE_VEC16;
+        A_smem[tid] = A_ptr[tid];
       }
 
       for (int i = 0; i < B_TILE_VEC16; i += 256) {
@@ -3599,9 +3600,9 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
     int sparsity_idx = (lane_id & 1) ? SPARSITY_ODD : SPARSITY_EVEN;
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      const f16x8 *A_tile_base = A_global + k_outer * A_tile_size_in_vec16;
+      const f16x8 *A_ptr = A_global + k_outer * A_tile_size_in_vec16;
       if (tid < A_tile_size_in_vec16) {
-        A_shared[tid] = A_tile_base[tid];
+        A_shared[tid] = A_ptr[tid];
       }
 
       for (int i = 0; i < B_tile_size_in_vec16; i += 256) {

--- a/matmul.hip
+++ b/matmul.hip
@@ -3576,7 +3576,6 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
     using f16x8 =
         __attribute__((__vector_size__(8 * sizeof(_Float16)))) _Float16;
     using f32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
-    using i8x16 = __attribute__((__vector_size__(16))) int8_t;
 
     union {
       f16x4 vec;
@@ -3594,14 +3593,14 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
     constexpr int A_tile_size_in_vec16 = 8 * KS * 4;
     constexpr int B_tile_size_in_vec16 = NS * KS * 64;
 
-    const i8x16 *A_global = static_cast<const i8x16 *>(A_data) +
+    const f16x8 *A_global = static_cast<const f16x8 *>(A_data) +
                             m_outer * K_outer * A_tile_size_in_vec16;
-    const i8x16 *B_global = static_cast<const i8x16 *>(B_data) +
+    const f16x8 *B_global = static_cast<const f16x8 *>(B_data) +
                             n_outer * K_outer * B_tile_size_in_vec16;
-    const i8x16 *B_global_ptr = B_global + tid;
+    const f16x8 *B_global_ptr = B_global + tid;
 
     __shared__ int8_t A_shared[KS * 512];
-    __shared__ i8x16 B_shared[B_tile_size_in_vec16];
+    __shared__ f16x8 B_shared[B_tile_size_in_vec16];
 
     int a_row_prod = tid / (KS * 4);
     int a_k_chunk = tid % (KS * 4);
@@ -3622,11 +3621,10 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
     int sparsity_idx = (lane_id & 1) ? SPARSITY_ODD : SPARSITY_EVEN;
 
     for (int k_outer = 0; k_outer < K_outer; ++k_outer) {
-      const i8x16 *A_tile_base = A_global + k_outer * A_tile_size_in_vec16;
+      const f16x8 *A_tile_base = A_global + k_outer * A_tile_size_in_vec16;
 
       if (tid < A_tile_size_in_vec16) {
-        auto global_idx = a_row_prod * (KS * 4) + a_k_chunk;
-        i8x16 a_loaded = A_tile_base[a_row_prod * (KS * 4) + a_k_chunk];
+        f16x8 a_loaded = A_tile_base[a_row_prod * (KS * 4) + a_k_chunk];
         int32_t reg0 = reinterpret_cast<int32_t *>(&a_loaded)[0]; // [K0, K1]
         int32_t reg1 = reinterpret_cast<int32_t *>(&a_loaded)[1]; // [K2, K3]
         int32_t reg2 = reinterpret_cast<int32_t *>(&a_loaded)[2]; // [K4, K5]
@@ -4059,62 +4057,62 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3
 };
 
 int main() {
-  std::printf("Best-performing kernels for each element types:\n\n");
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3<
-       8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
-       12, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8, 8>());
-  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
+  // std::printf("Best-performing kernels for each element types:\n\n");
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3<
+  //      8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
+  //      12, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8, 8>());
+  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
 
-  std::printf("\n\n\nOther kernels:\n\n");
-  test(MmtKernel_generic<Type::SI8, Type::SI8, Type::SI32, 3, 5, 2>());
-  test(MmtKernel_generic<Type::FP16, Type::FP16, Type::FP32, 3, 5, 2>());
-  test(MmtKernel_generic<Type::FP32, Type::FP32, Type::FP32, 3, 5, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<4, 8>());
-  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor());
-  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC());
-  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct());
-  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4());
-  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4());
-  test(MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct());
-  test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct());
-  test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 8>());
-  test(
-      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 12>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 12>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2<
-       8, 8>());
-  test(
-      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts<
-          8, 8>());
-  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
-  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
-  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
-  test(
-      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive<
-          8, 8>());
-  test(
-      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2<
-          8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2<8, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
-       8, 8>());
+  // std::printf("\n\n\nOther kernels:\n\n");
+  // test(MmtKernel_generic<Type::SI8, Type::SI8, Type::SI32, 3, 5, 2>());
+  // test(MmtKernel_generic<Type::FP16, Type::FP16, Type::FP32, 3, 5, 2>());
+  // test(MmtKernel_generic<Type::FP32, Type::FP32, Type::FP32, 3, 5, 2>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<4, 8>());
+  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor());
+  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC());
+  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct());
+  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4());
+  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4());
+  // test(MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct());
+  // test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct());
+  // test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 4>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 8>());
+  // test(
+  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 12>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 4>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 12>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 4>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2<
+  //      8, 8>());
+  // test(
+  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts<
+  //         8, 8>());
+  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
+  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
+  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
+  // test(
+  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive<
+  //         8, 8>());
+  // test(
+  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2<
+  //         8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2<8, 8>());
+  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
+  //      8, 8>());
 
   std::printf("\n\n\nSMFMAC sparse trick experiments:\n\n");
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 2>());
@@ -4130,13 +4128,13 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
 
-  std::printf("\n\n\nStream-K experiments:\n\n");
-  test(
-      MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8,
-                                                                          8>());
-  test(MmtKernel_StreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
-       8, 8>());
-  test(
-      MmtKernel_HybridStreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
-          8, 8>());
+  // std::printf("\n\n\nStream-K experiments:\n\n");
+  // test(
+  //     MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8,
+  //                                                                         8>());
+  // test(MmtKernel_StreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
+  //      8, 8>());
+  // test(
+  //     MmtKernel_HybridStreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
+  //         8, 8>());
 }

--- a/matmul.hip
+++ b/matmul.hip
@@ -3377,6 +3377,8 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
 // partial sums over complementary K indices, which are
 // reduced (D[0]+D[1], D[2]+D[3]) to recover the 8 complete
 // dense output rows.
+// Inspired by the implementation described in:
+// https://huggingface.co/blog/mi300kernels
 template <int NS, int KS>
 class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     : public MmtKernel {

--- a/matmul.hip
+++ b/matmul.hip
@@ -4057,62 +4057,62 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3
 };
 
 int main() {
-  // std::printf("Best-performing kernels for each element types:\n\n");
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3<
-  //      8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
-  //      12, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8, 8>());
-  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
+  std::printf("Best-performing kernels for each element types:\n\n");
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipeline_v3<
+       8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
+       12, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8, 8>());
+  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
 
-  // std::printf("\n\n\nOther kernels:\n\n");
-  // test(MmtKernel_generic<Type::SI8, Type::SI8, Type::SI32, 3, 5, 2>());
-  // test(MmtKernel_generic<Type::FP16, Type::FP16, Type::FP32, 3, 5, 2>());
-  // test(MmtKernel_generic<Type::FP32, Type::FP32, Type::FP32, 3, 5, 2>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<4, 8>());
-  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor());
-  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC());
-  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct());
-  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4());
-  // test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4());
-  // test(MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct());
-  // test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct());
-  // test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 4>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 8>());
-  // test(
-  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 12>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 4>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 12>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 4>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2<
-  //      8, 8>());
-  // test(
-  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts<
-  //         8, 8>());
-  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
-  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
-  // test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
-  // test(
-  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive<
-  //         8, 8>());
-  // test(
-  //     MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2<
-  //         8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2<8, 8>());
-  // test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
-  //      8, 8>());
+  std::printf("\n\n\nOther kernels:\n\n");
+  test(MmtKernel_generic<Type::SI8, Type::SI8, Type::SI32, 3, 5, 2>());
+  test(MmtKernel_generic<Type::FP16, Type::FP16, Type::FP32, 3, 5, 2>());
+  test(MmtKernel_generic<Type::FP32, Type::FP32, Type::FP32, 3, 5, 2>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_32x32x16i8_shared<4, 8>());
+  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_rowmajor());
+  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_directAB_rowmajorC());
+  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct());
+  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4());
+  test(MmtKernel_64t_amdgcn_mfma_f32_16x16x4f32_direct_Kx4_unrollx4());
+  test(MmtKernel_128t_1x2_amdgcn_mfma_f32_16x16x4f32_direct());
+  test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_direct());
+  test(MmtKernel_256t_2x2_amdgcn_mfma_f32_16x16x4f32_shared());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<4, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 8>());
+  test(
+      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_directA_sharedB<8, 12>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<4, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared<8, 12>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 4>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<4, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_subgroup2x2<
+       8, 8>());
+  test(
+      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_misguidednobankconflicts<
+          8, 8>());
+  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 12>());
+  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<8, 16>());
+  test(MmtKernel_1024t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4<16, 16>());
+  test(
+      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_naive<
+          8, 8>());
+  test(
+      MmtKernel_256t_MSxNS_amdgcn_mfma_f32_16x16x4f32_shared_Kx4_doublebuffer_take2<
+          8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2<8, 8>());
+  test(MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared_Kx2_pipelineload<
+       8, 8>());
 
   std::printf("\n\n\nSMFMAC sparse trick experiments:\n\n");
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 2>());
@@ -4128,13 +4128,13 @@ int main() {
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
   test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
 
-  // std::printf("\n\n\nStream-K experiments:\n\n");
-  // test(
-  //     MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8,
-  //                                                                         8>());
-  // test(MmtKernel_StreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
-  //      8, 8>());
-  // test(
-  //     MmtKernel_HybridStreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
-  //         8, 8>());
+  std::printf("\n\n\nStream-K experiments:\n\n");
+  test(
+      MmtKernel_StreamK_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<8,
+                                                                          8>());
+  test(MmtKernel_StreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
+       8, 8>());
+  test(
+      MmtKernel_HybridStreamKTree_256t_MSxNS_amdgcn_mfma_f32_16x16x16f16_shared_Kx2<
+          8, 8>());
 }

--- a/matmul.hip
+++ b/matmul.hip
@@ -3455,7 +3455,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     const int a_m_pair = (lane % 16) / 2;
     const int odd_lane = lane % 2;
     const int a_k_half = lane / 16;
-    const int a_lds_base = a_m_pair * (KS * 64) + a_k_half * 16 + odd_lane * 8;
+    const int a_lds_base = a_m_pair * (KS * 64) + a_k_half * 16;
 
     const int b_cons_n_col = lane % 16;
     const int b_cons_k_slice = lane / 16;
@@ -3475,48 +3475,36 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // We can represent a dense row across an even/odd lane pair as a sparse
-        // row by allowing even tids to hold positions {0,1} and odd tids to
-        // hold {2,3} within each group of 4:
+        // Both lanes in a pair load the same 16 bytes from LDS:
+        //   all:  K0 K1 K2 K3 | K4 K5 K6 K7 | K8 K9 K10 K11 | K12 K13 K14 K15
         //
-        //   even: K0 K1 _  _  K4 K5 _  _  ...
-        //   odd:  _  _  K2 K3 _  _  K6 K7 ...
+        // Viewed as two i16x4 halves (a_lo and a_hi):
+        //   a_lo: {K0K1, K2K3, K4K5, K6K7}
+        //   a_hi: {K8K9, K10K11, K12K13, K14K15}
         //
-        // From LDS, each pair of lanes loads the following:
-        //   even: K0 K1 K2 K3 | K4 K5 K6 K7
-        //   odd:  K8 K9 K10 K11 | K12 K13 K14 K15
-        // But this must be transformed to align with the sparsity index that
-        // represents:
-        //   even: K0 K1 K4 K5 | K8 K9 K12 K13
-        //   odd:  K2 K3 K6 K7 | K10 K11 K14 K15
-
-        // Load A from LDS: 8 bytes for this lane's groups
+        // Shufflevector extracts even/odd i16 elements from each half:
+        //   lo0 = {K0K1, K4K5}    hi0 = {K2K3, K6K7}
+        //   lo1 = {K8K9, K12K13}  hi1 = {K10K11, K14K15}
+        //
+        // Even lanes select lo, odd lanes select hi:
+        //   even: {K0K1, K4K5,  K8K9, K12K13}
+        //   odd:  {K2K3, K6K7,  K10K11, K14K15}
         auto *a_ptr =
-            reinterpret_cast<int2 *>(A_smem_bytes + a_lds_base + kb * 64);
-        auto a_i16 = __builtin_bit_cast(i16x4, *a_ptr);
-        // Shuffle 16-bit halves
-        // even: lo={K0,K1,K4,K5}   hi={K2,K3,K6,K7}
-        // odd:  lo={K8,K9,K12,K13} hi={K10,K11,K14,K15}
-        int pack_lo = __builtin_bit_cast(
-            int, __builtin_shufflevector(a_i16, a_i16, 0, 2));
-        int pack_hi = __builtin_bit_cast(
-            int, __builtin_shufflevector(a_i16, a_i16, 1, 3));
+            reinterpret_cast<i16x4 *>(A_smem_bytes + a_lds_base + kb * 64);
+        i16x4 a_lo = a_ptr[0];
+        i16x4 a_hi = a_ptr[1];
 
-        // DPP swap between even/odd neighbors
-        // even gets neighbor's: {K8,K9,K12,K13},
-        //                       {K10,K11,K14,K15}
-        // odd  gets neighbor's: {K0,K1,K4,K5},
-        //                       {K2,K3,K6,K7}
-        constexpr int kQuadPermSwap = 0xB1;
-        int neighbor_lo =
-            __builtin_amdgcn_mov_dpp(pack_lo, kQuadPermSwap, 0xF, 0xF, false);
-        int neighbor_hi =
-            __builtin_amdgcn_mov_dpp(pack_hi, kQuadPermSwap, 0xF, 0xF, false);
+        int lo0 =
+            __builtin_bit_cast(int, __builtin_shufflevector(a_lo, a_lo, 0, 2));
+        int hi0 =
+            __builtin_bit_cast(int, __builtin_shufflevector(a_lo, a_lo, 1, 3));
+        int lo1 =
+            __builtin_bit_cast(int, __builtin_shufflevector(a_hi, a_hi, 0, 2));
+        int hi1 =
+            __builtin_bit_cast(int, __builtin_shufflevector(a_hi, a_hi, 1, 3));
 
-        // even: {K0,K1,K4,K5,  K8,K9,K12,K13}
-        // odd:  {K2,K3,K6,K7,  K10,K11,K14,K15}
-        a_reg.i32[0] = !odd_lane ? pack_lo : neighbor_hi;
-        a_reg.i32[1] = !odd_lane ? neighbor_lo : pack_hi;
+        a_reg.i32[0] = !odd_lane ? lo0 : hi0;
+        a_reg.i32[1] = !odd_lane ? lo1 : hi1;
 
         for (int j = 0; j < NS / 4; ++j) {
           int n_block = j * 4 + warp;

--- a/matmul.hip
+++ b/matmul.hip
@@ -3482,7 +3482,8 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // Load A from LDS: 8 bytes spanning two lines (even or odd K half)
+        // Load A from LDS: 8 bytes spanning two lines (0, 1 for even or 2, 3
+        // for odd)
         auto *a_ptr = reinterpret_cast<int32_t *>(
             A_smem_raw + kb * 512 + a_cons_col * 4 + a_cons_is_odd * 256);
         a_reg.i32[0] = a_ptr[0];
@@ -3503,11 +3504,8 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       }
     }
 
-    // Post-processing: fuse even + odd K partial sums
-    // SMFMAC with the sparsity trick produces interleaved even/odd results:
-    //   acc[j][0] = row0 × B (even K),  acc[j][1] = row0 × B (odd K)
-    //   acc[j][2] = row1 × B (even K),  acc[j][3] = row1 × B (odd K)
-    // Fusing gives the complete dot product per row.
+    // Post-processing: fuse even + odd K partial sums to get the complete dot
+    // product per row
     for (int j = 0; j < NS / 4; ++j) {
       auto *d = reinterpret_cast<int32_t *>(&acc[j]);
       d[0] = d[0] + d[1]; // row0 complete

--- a/matmul.hip
+++ b/matmul.hip
@@ -8,12 +8,12 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <cxxabi.h>
 #include <optional>
 #include <random>
 #include <typeinfo>
 #include <vector>
-#include <cstring>
 
 typedef void (*mmt_func_t)(const void *, const void *, void *, void *, int, int,
                            int);
@@ -3358,6 +3358,25 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
   }
 };
 
+// The `smfmac` kernels are designed for skinny GEMMs (M=8)
+// by using sparse MFMA intrinsics to perform a fully dense
+// matmul. SMFMAC takes a 4:2-sparse operand A (where we
+// specify which 2 of 4 elements are non-zero via a sparsity
+// index) and a dense operand B. The "sparse trick" exploits
+// this by splitting each dense A row across an even/odd lane
+// pair, each holding half the K elements in a complementary
+// 4:2 pattern:
+//
+//   even: K0 K1 _  _  K4 K5 _  _  K8  K9  _   _  ...
+//   odd:  _  _  K2 K3 _  _  K6 K7 _   _  K10 K11 ...
+//
+// Together, the pair covers all K elements of one dense row.
+// The SMFMAC instruction sees 16 "sparse" rows (from a
+// 16x16x64 output tile) but physically only 8 dense rows
+// exist. After the intrinsic, each even/odd pair holds
+// partial sums over complementary K indices, which are
+// reduced (D[0]+D[1], D[2]+D[3]) to recover the 8 complete
+// dense output rows.
 template <int NS, int KS>
 class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     : public MmtKernel {
@@ -3431,11 +3450,10 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
     __shared__ i8x16 B_smem[B_TILE_VEC16];
     auto *A_smem_bytes = reinterpret_cast<int8_t *>(A_smem);
 
-    const int a_cons_m_pair = (lane % 16) / 2;
-    const int a_cons_is_odd = lane % 2;
-    const int a_cons_k_half = lane / 16;
-    const int a_cons_lds_base =
-        a_cons_m_pair * (KS * 64) + a_cons_k_half * 16 + a_cons_is_odd * 8;
+    const int a_m_pair = (lane % 16) / 2;
+    const int odd_lane = lane % 2;
+    const int a_k_half = lane / 16;
+    const int a_lds_base = a_m_pair * (KS * 64) + a_k_half * 16 + odd_lane * 8;
 
     const int b_cons_n_col = lane % 16;
     const int b_cons_k_slice = lane / 16;
@@ -3456,23 +3474,52 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // TODO: explain change.
+        // The sparse MFMA intrinsic takes non-zero
+        // elements plus sparsity indices that specify which
+        // 2 of 4 positions are non-zero. For a dense row:
+        //
+        //   K0 K1 K2 K3 K4 K5 ... K12 K13 K14 K15
+        //
+        // We can represent it across an even/odd lane pair as a sparse row by
+        // allowing even tids to hold positions {0,1} and odd tids to hold
+        // {2,3} within each group of 4:
+        //
+        //   even: K0 K1 _  _  K4 K5 _  _  ...
+        //   odd:  _  _  K2 K3 _  _  K6 K7 ...
+        //
+        // From LDS, each lane loads 8 contiguous elements
+        //   even: K0 K1 K2 K3 | K4 K5 K6 K7
+        //   odd:  K8 K9 K10 K11 | K12 K13 K14 K15
+        // But this must be transformed to align with the sparsity index:
+        //   even: K0 K1 K4 K5 | K8 K9 K12 K13
+        //   odd:  K2 K3 K6 K7 | K10 K11 K14 K15
+
         auto *a_ptr =
-            reinterpret_cast<int2 *>(A_smem_bytes + a_cons_lds_base + kb * 64);
+            reinterpret_cast<int2 *>(A_smem_bytes + a_lds_base + kb * 64);
         auto a_i16 = __builtin_bit_cast(i16x4, *a_ptr);
+        // Shuffle 16-bit halves
+        // even: lo={K0,K1,K4,K5}   hi={K2,K3,K6,K7}
+        // odd:  lo={K8,K9,K12,K13} hi={K10,K11,K14,K15}
         int pack_lo = __builtin_bit_cast(
             int, __builtin_shufflevector(a_i16, a_i16, 0, 2));
         int pack_hi = __builtin_bit_cast(
             int, __builtin_shufflevector(a_i16, a_i16, 1, 3));
 
+        // DPP swap between even/odd neighbors
+        // even gets neighbor's: {K8,K9,K12,K13},
+        //                       {K10,K11,K14,K15}
+        // odd  gets neighbor's: {K0,K1,K4,K5},
+        //                       {K2,K3,K6,K7}
         constexpr int kQuadPermSwap = 0xB1;
         int neighbor_lo =
             __builtin_amdgcn_mov_dpp(pack_lo, kQuadPermSwap, 0xF, 0xF, false);
         int neighbor_hi =
             __builtin_amdgcn_mov_dpp(pack_hi, kQuadPermSwap, 0xF, 0xF, false);
 
-        a_reg.i32[0] = (a_cons_is_odd == 0) ? pack_lo : neighbor_hi;
-        a_reg.i32[1] = (a_cons_is_odd == 0) ? neighbor_lo : pack_hi;
+        // even: {K0,K1,K4,K5,  K8,K9,K12,K13}
+        // odd:  {K2,K3,K6,K7,  K10,K11,K14,K15}
+        a_reg.i32[0] = !odd_lane ? pack_lo : neighbor_hi;
+        a_reg.i32[1] = !odd_lane ? neighbor_lo : pack_hi;
 
         for (int j = 0; j < NS / 4; ++j) {
           int n_block = j * 4 + warp;
@@ -3590,7 +3637,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
     auto *A_shared_bytes = reinterpret_cast<int8_t *>(A_shared);
 
     int a_m_row = (lane_id % 16) / 2;
-    int a_is_odd = lane_id % 2;
+    int odd_lane = lane_id % 2;
     int a_k_range = lane_id / 16;
     int a_lds_base = a_m_row * (KS * 64) + a_k_range * 16;
 
@@ -3615,8 +3662,10 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
         auto *a_ptr = reinterpret_cast<f16x8 *>(A_shared_bytes + a_lds_base +
                                                 k_bank * 64);
         auto *a_i32 = reinterpret_cast<int32_t *>(a_ptr);
-        a_reg.i32[0] = a_is_odd ? a_i32[1] : a_i32[0];
-        a_reg.i32[1] = a_is_odd ? a_i32[3] : a_i32[2];
+        // even: {K0, K1,  K4, K5}
+        // odd: {K2, K3,  K6, K7}
+        a_reg.i32[0] = odd_lane ? a_i32[1] : a_i32[0];
+        a_reg.i32[1] = odd_lane ? a_i32[3] : a_i32[2];
 
         for (int j = 0; j < NS / 4; ++j) {
           int n_block = j * 4 + warp_id;

--- a/matmul.hip
+++ b/matmul.hip
@@ -3475,7 +3475,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
       __syncthreads();
 
       for (int kb = 0; kb < KS; ++kb) {
-        // Both lanes in a pair load the same 16 bytes from LDS:
+        // Both lanes in a pair load the same 8 bytes from LDS:
         //   all:  K0 K1 K2 K3 | K4 K5 K6 K7 | K8 K9 K10 K11 | K12 K13 K14 K15
         //
         // Viewed as two i16x4 halves (a_lo and a_hi):

--- a/matmul.hip
+++ b/matmul.hip
@@ -3380,7 +3380,7 @@ class MmtKernel_256t_MSxNS_amdgcn_mfma_i32_16x16x32i8_shared
 // Inspired by the implementation described in:
 // https://huggingface.co/blog/mi300kernels
 template <int NS, int KS>
-class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
+class MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared
     : public MmtKernel {
   static_assert(NS >= 4 && !(NS % 4));
   static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
@@ -3551,7 +3551,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared
 };
 
 template <int NS, int KS>
-class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
+class MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared
     : public MmtKernel {
   static_assert(NS >= 4 && !(NS % 4));
   static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
@@ -3700,7 +3700,7 @@ class MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared
 // trick kernel above, which achieves the same M=8 matmul using
 // smfmac_i32_16x16x64_i8.
 template <int NS, int KS>
-class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
+class MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
     : public MmtKernel {
   static_assert(NS >= 4 && !(NS % 4));
   static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
@@ -3834,7 +3834,7 @@ class MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared
 // Since mfma processes K=16 vs smfmac's K=32, the inner loop runs
 // KS*2 iterations (nested kb=0..KS-1, kh=0..1).
 template <int NS, int KS>
-class MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared
+class MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared
     : public MmtKernel {
   static_assert(NS >= 4 && !(NS % 4));
   static_assert(KS >= 2 && KS <= 8 && !(KS % 2));
@@ -4388,30 +4388,30 @@ int main() {
        8, 8>());
 
   std::printf("\n\n\nSMFMAC sparse trick experiments:\n\n");
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_i32_16x16x64i8_shared<16, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 4>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 8>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 4>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<16, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 8>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 2>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
-  test(MmtKernel_256t_MSxNS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 4>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 8>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 2>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 4>());
-  test(MmtKernel_256t_8xNS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<16, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<4, 8>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<8, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_i32_16x16x64i8_shared<16, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<4, 8>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<8, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_i32_16x16x32i8_zeropad_shared<16, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<4, 8>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<8, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_smfmac_f32_16x16x32f16_shared<16, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<4, 8>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 2>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<8, 4>());
+  test(MmtKernel_256t_NSxKS_amdgcn_mfma_f32_16x16x16f16_zeropad_shared<16, 2>());
 
   std::printf("\n\n\nStream-K experiments:\n\n");
   test(


### PR DESCRIPTION
Sample sparse trick for skinny gemm implementation inspired by [HF kernel](https://github.com/huggingface/hf-rocm-kernels). Has 8bit input and 16bit input examples for CDNA3 variants of the intrinsic. 

Main differences from HF:
No warp specialization
No split-K
Simpler A/B tile LDS Layout
Swizzle A input on load from LDS rather than on store
Use 128 bit wide loads from LDS when possible
Support for >1 subgroups
personal preference: minimize inline asm

Main differences from other `matmul.hip` kernels:
No MS support atm (skinny gemm only)
Support for KS

assisted by claude 